### PR TITLE
fix: ログイン画面が表示されない無限スピナー問題を修正

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -39,6 +39,7 @@ export default function Home() {
 
       if (!user) {
         router.push("/login");
+        setLoading(false);
         return;
       }
 
@@ -48,11 +49,15 @@ export default function Home() {
         .eq("id", user.id)
         .single();
 
-      if (!profileData) return;
+      if (!profileData) {
+        setLoading(false);
+        return;
+      }
       setProfile(profileData);
 
       if (!profileData.household_id) {
         router.push("/household/new");
+        setLoading(false);
         return;
       }
 

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,7 +1,7 @@
 import { updateSession } from "@/lib/supabase/middleware";
 import type { NextRequest } from "next/server";
 
-export async function proxy(request: NextRequest) {
+export async function middleware(request: NextRequest) {
   return await updateSession(request);
 }
 


### PR DESCRIPTION
【原因1 (主因)】
src/proxy.ts が Next.js のミドルウェアとして認識されていなかった。
Next.js は src/middleware.ts (または middleware.ts) という名前で、
middleware という関数名を export するファイルのみをミドルウェアとして扱う。
proxy.ts という名前では完全に無視されるため、ミドルウェアが一切動作しておらず、
未認証ユーザーへのサーバーサイドリダイレクトが機能していなかった。

修正: src/proxy.ts → src/middleware.ts にリネームし、
      export 関数名を proxy → middleware に変更。

【原因2 (副因)】
src/app/page.tsx の load() 関数内で早期リターンする3箇所において
setLoading(false) が呼び出されておらず、スピナーが止まらない状態になっていた。
特に !profileData のケースはリダイレクトもなく永久にスピナーが回り続ける。

修正: 全ての早期リターン前に setLoading(false) を追加。

https://claude.ai/code/session_01VdpuTnZ4YVQjKpbkLxh5nT