### PR TITLE
fix: タスク追加時の重複表示バグを修正

### DIFF
--- a/src/hooks/use-tasks.ts
+++ b/src/hooks/use-tasks.ts
@@ -50,7 +50,10 @@ export function useTasks(householdId: string | null, categoryId?: string | null)
       .single();
 
     if (!error && data) {
-      setTasks((prev) => [data, ...prev]);
+      setTasks((prev) => {
+        if (prev.some((t) => t.id === data.id)) return prev;
+        return [data, ...prev];
+      });
     }
     return { data, error };
   };


### PR DESCRIPTION
addTaskのsetTasks呼び出しに重複チェックを追加。
SupabaseのリアルタイムイベントがaddTaskのレスポンスより先に届いた場合、
useRealtimeTasksがタスクをstateに追加した後にaddTaskがさらに同じタスクを
追加する競合状態が発生していた。addTask側でもIDによる重複チェックを行うことで修正。

https://claude.ai/code/session_01GC7JsMNRn5xe8kVrQ1baEK