### PR TITLE
fix: モバイルキーボードがボトムシートの追加ボタンと重なる問題を修正

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -30,6 +30,7 @@ export const viewport: Viewport = {
   maximumScale: 1,
   userScalable: false,
   themeColor: "#6366f1",
+  interactiveWidget: "resizes-content",
 };
 
 export default function RootLayout({


### PR DESCRIPTION
visualViewport APIでキーボード高さを検出し、BottomSheetの位置と
最大高さを動的に調整。Chrome Android向けにinteractiveWidget:
resizes-contentのviewport設定も追加。

https://claude.ai/code/session_01GLPoDEzdF7Vh59pBt3tpwe