### PR TITLE
「すべて」カテゴリタブを削除し、ユーザー追加カテゴリのみ表示

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -46,6 +46,13 @@ export default function Home() {
 
   useRealtimeTasks(householdId, setTasks);
 
+  // Auto-select first category when categories load and none is selected
+  useEffect(() => {
+    if (selectedCategoryId === null && categories.length > 0) {
+      setSelectedCategoryId(categories[0].id);
+    }
+  }, [categories, selectedCategoryId]);
+
   const tasks = useMemo(() => {
     if (!selectedCategoryId) return allTasks;
     return allTasks.filter((t) => t.category_id === selectedCategoryId);

--- a/src/components/category/category-tabs.tsx
+++ b/src/components/category/category-tabs.tsx
@@ -28,9 +28,9 @@ export function CategoryTabs({
   const indicatorRef = externalIndicatorRef ?? internalIndicatorRef;
   const tabButtonRefs = useRef<(HTMLButtonElement | null)[]>([]);
 
-  // All tab IDs in order: [null, ...category ids]
-  const tabIds: (string | null)[] = [null, ...categories.map((c) => c.id)];
-  const activeIndex = tabIds.indexOf(selectedId);
+  // Tab IDs in order: category ids only (no "すべて")
+  const tabIds: string[] = categories.map((c) => c.id);
+  const activeIndex = selectedId ? tabIds.indexOf(selectedId) : -1;
   const safeIndex = activeIndex === -1 ? 0 : activeIndex;
 
   const measureTabs = useCallback(() => {
@@ -130,8 +130,7 @@ export function CategoryTabs({
 
   // Get background color for active tab
   const getActiveBg = (index: number): string => {
-    if (index === 0) return "#e0e7ff"; // indigo-100
-    const cat = categories[index - 1];
+    const cat = categories[index];
     return cat ? `${cat.color}20` : "#e0e7ff";
   };
 
@@ -149,30 +148,18 @@ export function CategoryTabs({
         />
 
         {/* Tab buttons */}
-        <button
-          ref={(el) => { tabButtonRefs.current[0] = el; }}
-          onClick={() => handleSelect(null, 0)}
-          className="relative z-10 flex-1 flex items-center justify-center rounded-full py-1.5 text-sm font-medium transition-colors"
-        >
-          <span className={selectedId === null ? "text-indigo-700" : "text-gray-600"}>
-            すべて
-          </span>
-        </button>
-        {categories.map((cat, i) => {
-          const tabIndex = i + 1;
-          return (
-            <button
-              key={cat.id}
-              ref={(el) => { tabButtonRefs.current[tabIndex] = el; }}
-              onClick={() => handleSelect(cat.id, tabIndex)}
-              className="relative z-10 flex-1 flex items-center justify-center rounded-full py-1.5 text-sm font-medium transition-colors"
-            >
-              <span style={{ color: selectedId === cat.id ? cat.color : "#6b7280" }}>
-                {cat.name}
-              </span>
-            </button>
-          );
-        })}
+        {categories.map((cat, i) => (
+          <button
+            key={cat.id}
+            ref={(el) => { tabButtonRefs.current[i] = el; }}
+            onClick={() => handleSelect(cat.id, i)}
+            className="relative z-10 flex-1 flex items-center justify-center rounded-full py-1.5 text-sm font-medium transition-colors"
+          >
+            <span style={{ color: selectedId === cat.id ? cat.color : "#6b7280" }}>
+              {cat.name}
+            </span>
+          </button>
+        ))}
       </div>
     </div>
   );

--- a/src/components/task/swipeable-task-container.tsx
+++ b/src/components/task/swipeable-task-container.tsx
@@ -21,13 +21,13 @@ export function SwipeableTaskContainer({
 }: SwipeableTaskContainerProps) {
   const containerRef = useRef<HTMLDivElement>(null);
 
-  // Build ordered category id list: [null, ...category ids]
+  // Build ordered category id list: category ids only
   const categoryOrder = useMemo(
-    () => [null, ...categories.map((c) => c.id)] as (string | null)[],
+    () => categories.map((c) => c.id),
     [categories]
   );
 
-  const activeIndex = categoryOrder.indexOf(selectedCategoryId);
+  const activeIndex = selectedCategoryId ? categoryOrder.indexOf(selectedCategoryId) : -1;
   const safeIndex = activeIndex === -1 ? 0 : activeIndex;
 
   useSwipeableTab({
@@ -35,7 +35,7 @@ export function SwipeableTaskContainer({
     tabCount: categoryOrder.length,
     activeIndex: safeIndex,
     onChangeIndex: (index: number) => {
-      onCategoryChange(categoryOrder[index]);
+      onCategoryChange(categoryOrder[index] ?? null);
     },
     indicatorRefs,
   });


### PR DESCRIPTION
- CategoryTabs: 「すべて」ボタンとnullタブIDを削除、カテゴリのみのタブに変更
- SwipeableTaskContainer: categoryOrderからnullを削除
- page.tsx: カテゴリ読み込み時に最初のカテゴリを自動選択するuseEffectを追加

https://claude.ai/code/session_01TRuDSWzUCUnqBW3Ky3EJxv