### PR TITLE
チェックボックスのタップ領域を44pxに拡大

### DIFF
--- a/src/components/task/task-item.tsx
+++ b/src/components/task/task-item.tsx
@@ -92,30 +92,34 @@ export function TaskItem({
           )}
 
           {/* Checkbox */}
-          <motion.button
+          <button
             onClick={(e) => {
               e.stopPropagation();
               onToggle(task.id);
             }}
-            whileTap={{ scale: 0.85 }}
-            animate={task.is_done ? { scale: [1, 1.2, 1] } : {}}
-            transition={{ duration: 0.25 }}
-            className={`flex h-5 w-5 shrink-0 items-center justify-center rounded-full border-2 transition-colors ${
-              task.is_done
-                ? "border-green-500 bg-green-500"
-                : "border-gray-300 hover:border-indigo-400"
-            }`}
+            className="shrink-0 flex items-center justify-center p-3 -m-3 touch-manipulation"
           >
-            {task.is_done && (
-              <motion.div
-                initial={{ scale: 0, rotate: -90 }}
-                animate={{ scale: 1, rotate: 0 }}
-                transition={{ type: "spring", damping: 15, stiffness: 400 }}
-              >
-                <Check size={14} className="text-white" />
-              </motion.div>
-            )}
-          </motion.button>
+            <motion.span
+              whileTap={{ scale: 0.85 }}
+              animate={task.is_done ? { scale: [1, 1.2, 1] } : {}}
+              transition={{ duration: 0.25 }}
+              className={`flex h-5 w-5 items-center justify-center rounded-full border-2 transition-colors ${
+                task.is_done
+                  ? "border-green-500 bg-green-500"
+                  : "border-gray-300 hover:border-indigo-400"
+              }`}
+            >
+              {task.is_done && (
+                <motion.div
+                  initial={{ scale: 0, rotate: -90 }}
+                  animate={{ scale: 1, rotate: 0 }}
+                  transition={{ type: "spring", damping: 15, stiffness: 400 }}
+                >
+                  <Check size={14} className="text-white" />
+                </motion.div>
+              )}
+            </motion.span>
+          </button>
 
           {/* Content */}
           <div className="flex-1 min-w-0">


### PR DESCRIPTION
モバイルでの操作性向上のため、チェックボックスのヒットボックスを
20×20px から 44×44px に拡大。
- 外側の button に p-3 -m-3 を追加してタップ領域を確保
- 視覚的な円形は内側の motion.span に維持
- touch-manipulation で 300ms タップ遅延を解消
- アニメーション (whileTap/animate) は motion.span に移動

https://claude.ai/code/session_01Pk554nooVcz7CrrwerxAiw