### PR TITLE
カテゴリ切り替え時のタスク表示ちらつきとアニメーションを修正

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -167,6 +167,7 @@ export default function Home() {
             <TaskListSkeleton />
           ) : (
             <TaskList
+              key={selectedCategoryId}
               tasks={tasks}
               categories={categories}
               members={members}

--- a/src/components/task/task-list.tsx
+++ b/src/components/task/task-list.tsx
@@ -135,7 +135,7 @@ export function TaskList({
             items={localActiveTasks.map((t) => t.id)}
             strategy={verticalListSortingStrategy}
           >
-            <AnimatePresence mode="popLayout">
+            <AnimatePresence mode="popLayout" initial={false}>
               {localActiveTasks.map((task) => (
                 <TaskItem
                   key={task.id}
@@ -208,7 +208,7 @@ export function TaskList({
                 </motion.div>
               )}
             </AnimatePresence>
-            <AnimatePresence mode="popLayout">
+            <AnimatePresence mode="popLayout" initial={false}>
               {doneTasks.map((task) => (
                 <TaskItem
                   key={task.id}

--- a/src/hooks/use-swipeable-tab.ts
+++ b/src/hooks/use-swipeable-tab.ts
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef, useEffect, useCallback, type RefObject } from "react";
+import { flushSync } from "react-dom";
 
 export interface IndicatorRefs {
   barRef: RefObject<HTMLDivElement | null>;
@@ -179,9 +180,12 @@ export function useSwipeableTab({
       const onTransitionEnd = () => {
         container.style.transition = "";
         if (targetIndex !== idx) {
-          // Update state first so React renders new content,
-          // then reset transform in the same frame to avoid flicker
-          onChangeIndexRef.current(targetIndex);
+          // flushSync ensures React commits the new content to the DOM
+          // synchronously before we reset the transform, preventing
+          // the old category's tasks from flashing at position 0.
+          flushSync(() => {
+            onChangeIndexRef.current(targetIndex);
+          });
         }
         container.style.transform = "";
       };


### PR DESCRIPTION
- use-swipeable-tab: flushSyncでReact状態更新をDOM操作前に同期コミットし、
  スワイプ後に旧カテゴリのタスクが一瞬表示される問題を解消
- page.tsx: TaskListにkey={selectedCategoryId}を追加し、カテゴリ切り替え時に
  コンポーネントを再マウントすることでexit animationをスキップ
- task-list.tsx: AnimatePresenceにinitial={false}を追加し、再マウント時の
  enter animationを抑制（個別タスク追加時のアニメーションは維持）

https://claude.ai/code/session_0176LS4Whi7qyGPX8kytpC5A