### PR TITLE
fix(security): P1 リリースブロッカー3件を対応

### DIFF
--- a/src/components/auth/forgot-password-form.tsx
+++ b/src/components/auth/forgot-password-form.tsx
@@ -26,10 +26,14 @@ export function ForgotPasswordForm() {
     return (
       <div className="rounded-lg bg-green-50 p-4 text-sm text-green-700">
         メールを送信しました。メールボックスをご確認ください。
-        <br />
-        <span className="text-xs text-green-600">
-          （ローカル開発時は localhost:54324 の Inbucket で確認できます）
-        </span>
+        {process.env.NODE_ENV === "development" && (
+          <>
+            <br />
+            <span className="text-xs text-green-600">
+              （ローカル開発時は localhost:54324 の Inbucket で確認できます）
+            </span>
+          </>
+        )}
       </div>
     );
   }

--- a/src/components/household/join-form.tsx
+++ b/src/components/household/join-form.tsx
@@ -73,14 +73,14 @@ export function JoinHouseholdForm() {
           value={code}
           onChange={(e) => setCode(e.target.value)}
           required
-          maxLength={6}
+          maxLength={16}
           className="rounded-lg border border-gray-300 px-4 py-3 text-center text-2xl font-mono tracking-widest uppercase outline-none transition-colors focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20"
-          placeholder="XXXXXX"
+          placeholder="XXXXXXXXXXXXXXXX"
         />
       </div>
       <button
         type="submit"
-        disabled={loading || code.length < 6}
+        disabled={loading || code.length < 16}
         className="mt-2 rounded-lg bg-indigo-600 px-4 py-3 text-base font-semibold text-white transition-colors hover:bg-indigo-700 disabled:opacity-50"
       >
         {loading ? "参加中..." : "ハウスホールドに参加"}

--- a/src/components/task/task-detail-modal.tsx
+++ b/src/components/task/task-detail-modal.tsx
@@ -16,6 +16,15 @@ interface TaskDetailModalProps {
   onDelete: (id: string) => Promise<void>;
 }
 
+function isValidUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return ["http:", "https:"].includes(parsed.protocol);
+  } catch {
+    return false;
+  }
+}
+
 export function TaskDetailModal({
   task,
   isOpen,
@@ -30,6 +39,7 @@ export function TaskDetailModal({
   const [dueDate, setDueDate] = useState("");
   const [memo, setMemo] = useState("");
   const [url, setUrl] = useState("");
+  const [urlError, setUrlError] = useState("");
 
   useEffect(() => {
     if (task) {
@@ -44,6 +54,11 @@ export function TaskDetailModal({
   if (!task) return null;
 
   const handleSave = async () => {
+    if (url && !isValidUrl(url)) {
+      setUrlError("URLはhttpまたはhttpsで始まる必要があります");
+      return;
+    }
+    setUrlError("");
     await onUpdate(task.id, {
       title: title.trim(),
       category_id: categoryId,
@@ -160,11 +175,11 @@ export function TaskDetailModal({
           <div className="flex gap-2">
             <input
               value={url}
-              onChange={(e) => setUrl(e.target.value)}
+              onChange={(e) => { setUrl(e.target.value); setUrlError(""); }}
               placeholder="https://..."
-              className="flex-1 rounded-lg border border-gray-300 px-4 py-2 text-sm outline-none focus:border-indigo-500"
+              className={`flex-1 rounded-lg border px-4 py-2 text-sm outline-none focus:border-indigo-500 ${urlError ? "border-red-400" : "border-gray-300"}`}
             />
-            {url && (
+            {url && !urlError && isValidUrl(url) && (
               <a
                 href={url}
                 target="_blank"
@@ -175,6 +190,9 @@ export function TaskDetailModal({
               </a>
             )}
           </div>
+          {urlError && (
+            <p className="mt-1 text-xs text-red-500">{urlError}</p>
+          )}
         </div>
 
         {/* Meta info */}

--- a/supabase/migrations/005_strengthen_invite_code.sql
+++ b/supabase/migrations/005_strengthen_invite_code.sql
@@ -1,0 +1,18 @@
+-- ============================================
+-- P1-1: 招待コードの強度強化
+-- MD5(random()) の6文字 → gen_random_bytes(8) の16文字hexに変更
+-- ============================================
+
+create or replace function public.generate_invite_code(p_household_id uuid)
+returns text as $$
+declare
+  v_code text;
+begin
+  v_code := upper(encode(gen_random_bytes(8), 'hex'));
+  update public.households
+  set invite_code = v_code,
+      invite_code_expires_at = now() + interval '24 hours'
+  where id = p_household_id;
+  return v_code;
+end;
+$$ language plpgsql security definer;


### PR DESCRIPTION
- P1-1: 招待コードをMD5(6文字)からgen_random_bytes(16文字hex)に強化
  - supabase/migrations/005_strengthen_invite_code.sql を追加
  - join-form の maxLength / placeholder / 送信可能条件を16文字に更新
- P1-2: タスクURLにhttp/httpsプロトコル検証を追加
  - task-detail-modal で isValidUrl() によるバリデーション実施
  - 無効URL時はエラー表示してブロック、外部リンクボタンも非表示化
- P1-3: forgot-password-form のInbucketヒントをNODE_ENV=development時のみ表示

https://claude.ai/code/session_01ASeAgdeqKb8xE8rgSaVSU7