### PR TITLE
refine: タスク一覧UIをよりコンパクトに改善

### DIFF
--- a/src/components/task/task-item.tsx
+++ b/src/components/task/task-item.tsx
@@ -76,7 +76,7 @@ export function TaskItem({
       >
         {/* Card */}
         <div
-          className="relative flex items-center gap-2.5 bg-white px-3 py-2.5 rounded-lg shadow-sm border border-gray-100 cursor-pointer transition-colors"
+          className="relative flex items-center gap-2 bg-white px-3 py-1.5 rounded-lg shadow-sm border border-gray-100 cursor-pointer transition-colors"
           onClick={handleCardClick}
         >
           {/* Drag handle (only for sortable active tasks) */}
@@ -130,34 +130,25 @@ export function TaskItem({
             >
               {task.title}
             </p>
-            <div className="flex items-center gap-2 mt-0.5">
-              {category && (
-                <span
-                  className="inline-flex items-center text-xs px-1.5 py-0.5 rounded-full leading-none"
-                  style={{
-                    backgroundColor: `${category.color}15`,
-                    color: category.color,
-                  }}
-                >
-                  {category.name}
-                </span>
-              )}
-              {task.due_date && (
-                <span
-                  className={`flex items-center gap-0.5 text-xs ${
-                    isOverdue ? "text-red-500 font-medium" : "text-gray-500"
-                  }`}
-                >
-                  <Calendar size={10} />
-                  {formatDueDate(task.due_date)}
-                </span>
-              )}
-              {createdBy && (
-                <span className="text-xs text-gray-400">
-                  {createdBy.nickname}
-                </span>
-              )}
-            </div>
+            {(task.due_date || createdBy) && (
+              <div className="flex items-center gap-2 mt-0.5">
+                {task.due_date && (
+                  <span
+                    className={`flex items-center gap-0.5 text-xs ${
+                      isOverdue ? "text-red-500 font-medium" : "text-gray-500"
+                    }`}
+                  >
+                    <Calendar size={10} />
+                    {formatDueDate(task.due_date)}
+                  </span>
+                )}
+                {createdBy && (
+                  <span className="text-xs text-gray-400">
+                    {createdBy.nickname}
+                  </span>
+                )}
+              </div>
+            )}
           </div>
         </div>
       </motion.div>

--- a/src/components/task/task-list.tsx
+++ b/src/components/task/task-list.tsx
@@ -124,7 +124,7 @@ export function TaskList({
 
   return (
     <>
-      <div className="flex flex-col gap-1.5 px-4 pb-24">
+      <div className="flex flex-col gap-1 px-4 pb-24">
         <DndContext
           sensors={sensors}
           collisionDetection={closestCenter}


### PR DESCRIPTION
- タスクカードからカテゴリ名バッジを削除（視覚的ノイズを低減）
- カードの縦padding を py-2.5 → py-1.5 に縮小し、一覧性を向上
- カード間のgapを gap-1.5 → gap-1 に縮小
- メタデータ行（期日・作成者）を期日または作成者が存在する場合のみ表示するよう条件化

https://claude.ai/code/session_01YLBKTjXwXEeez9cKasP9xV