### PR TITLE
feat: メール通知を日本語テンプレートに変更

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -226,16 +226,20 @@ otp_expiry = 3600
 # admin_email = "admin@email.com"
 # sender_name = "Admin"
 
-# Uncomment to customize email template
-# [auth.email.template.invite]
-# subject = "You have been invited"
-# content_path = "./supabase/templates/invite.html"
+# メール確認テンプレート（サインアップ時）
+[auth.email.template.confirmation]
+subject = "【家族タスクアプリ】メールアドレスの確認"
+content_path = "./templates/confirmation.html"
 
-# Uncomment to customize notification email template
-# [auth.email.notification.password_changed]
-# enabled = true
-# subject = "Your password has been changed"
-# content_path = "./templates/password_changed_notification.html"
+# パスワード再設定テンプレート
+[auth.email.template.recovery]
+subject = "【家族タスクアプリ】パスワードの再設定"
+content_path = "./templates/recovery.html"
+
+# 招待テンプレート
+[auth.email.template.invite]
+subject = "【家族タスクアプリ】招待のご案内"
+content_path = "./templates/invite.html"
 
 [auth.sms]
 # Allow/disallow new user signups via SMS to your project.

--- a/supabase/templates/confirmation.html
+++ b/supabase/templates/confirmation.html
@@ -1,0 +1,122 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>メールアドレスの確認</title>
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+      background-color: #f3f4f6;
+      font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Hiragino Kaku Gothic ProN",
+        "Noto Sans JP", "Yu Gothic", sans-serif;
+      color: #111827;
+    }
+    .wrapper {
+      max-width: 560px;
+      margin: 40px auto;
+      background-color: #ffffff;
+      border-radius: 12px;
+      overflow: hidden;
+      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+    }
+    .header {
+      background-color: #6366f1;
+      padding: 32px 40px;
+      text-align: center;
+    }
+    .header h1 {
+      margin: 0;
+      font-size: 22px;
+      color: #ffffff;
+      font-weight: 700;
+      letter-spacing: 0.02em;
+    }
+    .header p {
+      margin: 6px 0 0;
+      font-size: 13px;
+      color: #c7d2fe;
+    }
+    .body {
+      padding: 36px 40px;
+    }
+    .body p {
+      margin: 0 0 16px;
+      font-size: 15px;
+      line-height: 1.7;
+      color: #374151;
+    }
+    .button-wrap {
+      text-align: center;
+      margin: 28px 0;
+    }
+    .button {
+      display: inline-block;
+      background-color: #6366f1;
+      color: #ffffff !important;
+      text-decoration: none;
+      padding: 14px 36px;
+      border-radius: 8px;
+      font-size: 15px;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+    }
+    .note {
+      font-size: 13px;
+      color: #6b7280;
+      line-height: 1.6;
+      margin: 0;
+    }
+    .divider {
+      border: none;
+      border-top: 1px solid #e5e7eb;
+      margin: 28px 0;
+    }
+    .footer {
+      padding: 20px 40px;
+      background-color: #f9fafb;
+      text-align: center;
+    }
+    .footer p {
+      margin: 0;
+      font-size: 12px;
+      color: #9ca3af;
+      line-height: 1.6;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+    <div class="header">
+      <h1>家族タスクアプリ</h1>
+      <p>メールアドレスの確認</p>
+    </div>
+    <div class="body">
+      <p>ご登録ありがとうございます。</p>
+      <p>
+        以下のボタンをクリックして、メールアドレスの確認を完了してください。
+        確認が完了するとアカウントが有効になります。
+      </p>
+      <div class="button-wrap">
+        <a class="button" href="{{ .ConfirmationURL }}">メールアドレスを確認する</a>
+      </div>
+      <hr class="divider" />
+      <p class="note">
+        ボタンが機能しない場合は、以下のURLをブラウザに貼り付けてください：<br />
+        <a href="{{ .ConfirmationURL }}" style="color: #6366f1; word-break: break-all;">
+          {{ .ConfirmationURL }}
+        </a>
+      </p>
+      <p class="note" style="margin-top: 12px;">
+        このメールに心当たりがない場合は、無視していただいて構いません。
+        このリンクは24時間有効です。
+      </p>
+    </div>
+    <div class="footer">
+      <p>このメールは家族タスクアプリから自動送信されています。</p>
+      <p>返信しても対応できませんのでご了承ください。</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/supabase/templates/invite.html
+++ b/supabase/templates/invite.html
@@ -1,0 +1,120 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>招待のご案内</title>
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+      background-color: #f3f4f6;
+      font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Hiragino Kaku Gothic ProN",
+        "Noto Sans JP", "Yu Gothic", sans-serif;
+      color: #111827;
+    }
+    .wrapper {
+      max-width: 560px;
+      margin: 40px auto;
+      background-color: #ffffff;
+      border-radius: 12px;
+      overflow: hidden;
+      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+    }
+    .header {
+      background-color: #6366f1;
+      padding: 32px 40px;
+      text-align: center;
+    }
+    .header h1 {
+      margin: 0;
+      font-size: 22px;
+      color: #ffffff;
+      font-weight: 700;
+      letter-spacing: 0.02em;
+    }
+    .header p {
+      margin: 6px 0 0;
+      font-size: 13px;
+      color: #c7d2fe;
+    }
+    .body {
+      padding: 36px 40px;
+    }
+    .body p {
+      margin: 0 0 16px;
+      font-size: 15px;
+      line-height: 1.7;
+      color: #374151;
+    }
+    .button-wrap {
+      text-align: center;
+      margin: 28px 0;
+    }
+    .button {
+      display: inline-block;
+      background-color: #6366f1;
+      color: #ffffff !important;
+      text-decoration: none;
+      padding: 14px 36px;
+      border-radius: 8px;
+      font-size: 15px;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+    }
+    .note {
+      font-size: 13px;
+      color: #6b7280;
+      line-height: 1.6;
+      margin: 0;
+    }
+    .divider {
+      border: none;
+      border-top: 1px solid #e5e7eb;
+      margin: 28px 0;
+    }
+    .footer {
+      padding: 20px 40px;
+      background-color: #f9fafb;
+      text-align: center;
+    }
+    .footer p {
+      margin: 0;
+      font-size: 12px;
+      color: #9ca3af;
+      line-height: 1.6;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+    <div class="header">
+      <h1>家族タスクアプリ</h1>
+      <p>招待のご案内</p>
+    </div>
+    <div class="body">
+      <p>家族タスクアプリへ招待されました。</p>
+      <p>
+        以下のボタンをクリックして、アカウントを作成してグループに参加してください。
+      </p>
+      <div class="button-wrap">
+        <a class="button" href="{{ .ConfirmationURL }}">招待を受け入れる</a>
+      </div>
+      <hr class="divider" />
+      <p class="note">
+        ボタンが機能しない場合は、以下のURLをブラウザに貼り付けてください：<br />
+        <a href="{{ .ConfirmationURL }}" style="color: #6366f1; word-break: break-all;">
+          {{ .ConfirmationURL }}
+        </a>
+      </p>
+      <p class="note" style="margin-top: 12px;">
+        このメールに心当たりがない場合は、無視していただいて構いません。
+      </p>
+    </div>
+    <div class="footer">
+      <p>このメールは家族タスクアプリから自動送信されています。</p>
+      <p>返信しても対応できませんのでご了承ください。</p>
+    </div>
+  </div>
+</body>
+</html>

--- a/supabase/templates/recovery.html
+++ b/supabase/templates/recovery.html
@@ -1,0 +1,121 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>パスワードの再設定</title>
+  <style>
+    body {
+      margin: 0;
+      padding: 0;
+      background-color: #f3f4f6;
+      font-family: -apple-system, BlinkMacSystemFont, "Hiragino Sans", "Hiragino Kaku Gothic ProN",
+        "Noto Sans JP", "Yu Gothic", sans-serif;
+      color: #111827;
+    }
+    .wrapper {
+      max-width: 560px;
+      margin: 40px auto;
+      background-color: #ffffff;
+      border-radius: 12px;
+      overflow: hidden;
+      box-shadow: 0 1px 4px rgba(0, 0, 0, 0.08);
+    }
+    .header {
+      background-color: #6366f1;
+      padding: 32px 40px;
+      text-align: center;
+    }
+    .header h1 {
+      margin: 0;
+      font-size: 22px;
+      color: #ffffff;
+      font-weight: 700;
+      letter-spacing: 0.02em;
+    }
+    .header p {
+      margin: 6px 0 0;
+      font-size: 13px;
+      color: #c7d2fe;
+    }
+    .body {
+      padding: 36px 40px;
+    }
+    .body p {
+      margin: 0 0 16px;
+      font-size: 15px;
+      line-height: 1.7;
+      color: #374151;
+    }
+    .button-wrap {
+      text-align: center;
+      margin: 28px 0;
+    }
+    .button {
+      display: inline-block;
+      background-color: #6366f1;
+      color: #ffffff !important;
+      text-decoration: none;
+      padding: 14px 36px;
+      border-radius: 8px;
+      font-size: 15px;
+      font-weight: 600;
+      letter-spacing: 0.02em;
+    }
+    .note {
+      font-size: 13px;
+      color: #6b7280;
+      line-height: 1.6;
+      margin: 0;
+    }
+    .divider {
+      border: none;
+      border-top: 1px solid #e5e7eb;
+      margin: 28px 0;
+    }
+    .footer {
+      padding: 20px 40px;
+      background-color: #f9fafb;
+      text-align: center;
+    }
+    .footer p {
+      margin: 0;
+      font-size: 12px;
+      color: #9ca3af;
+      line-height: 1.6;
+    }
+  </style>
+</head>
+<body>
+  <div class="wrapper">
+    <div class="header">
+      <h1>家族タスクアプリ</h1>
+      <p>パスワードの再設定</p>
+    </div>
+    <div class="body">
+      <p>パスワード再設定のリクエストを受け付けました。</p>
+      <p>
+        以下のボタンをクリックして、新しいパスワードを設定してください。
+      </p>
+      <div class="button-wrap">
+        <a class="button" href="{{ .ConfirmationURL }}">パスワードを再設定する</a>
+      </div>
+      <hr class="divider" />
+      <p class="note">
+        ボタンが機能しない場合は、以下のURLをブラウザに貼り付けてください：<br />
+        <a href="{{ .ConfirmationURL }}" style="color: #6366f1; word-break: break-all;">
+          {{ .ConfirmationURL }}
+        </a>
+      </p>
+      <p class="note" style="margin-top: 12px;">
+        このリクエストに心当たりがない場合は、このメールを無視してください。
+        パスワードは変更されません。このリンクは1時間有効です。
+      </p>
+    </div>
+    <div class="footer">
+      <p>このメールは家族タスクアプリから自動送信されています。</p>
+      <p>返信しても対応できませんのでご了承ください。</p>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
サインアップ確認・パスワードリセット・招待の3種類のメールを
日本語UIに統一し、アプリのブランドカラー（インディゴ）に合わせたHTMLテンプレートを追加。
config.toml でテンプレートの件名とパスを設定。

- supabase/templates/confirmation.html — メールアドレス確認
- supabase/templates/recovery.html    — パスワード再設定
- supabase/templates/invite.html      — 招待

https://claude.ai/code/session_013VKAtdF9D1TxxjVqkngHhy