### PR TITLE
refactor: 重複ロジックを共通ユーティリティに抽出

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,8 +3,6 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { Settings } from "lucide-react";
-import { toast } from "sonner";
-import { createClient } from "@/lib/supabase/client";
 import { CategoryTabs } from "@/components/category/category-tabs";
 import { TaskList } from "@/components/task/task-list";
 import { TaskListSkeleton } from "@/components/task/task-list-skeleton";
@@ -15,19 +13,17 @@ import { Fab } from "@/components/ui/fab";
 import { useTasks } from "@/hooks/use-tasks";
 import { useCategories } from "@/hooks/use-categories";
 import { useRealtimeTasks } from "@/hooks/use-realtime-tasks";
+import { usePageData } from "@/hooks/use-page-data";
 import type { TabMeasurements } from "@/components/category/category-tabs";
 import type { IndicatorRefs } from "@/hooks/use-swipeable-tab";
-import type { Profile, Task } from "@/types";
+import type { Task } from "@/types";
 
 export default function Home() {
   const router = useRouter();
-  const [profile, setProfile] = useState<Profile | null>(null);
-  const [members, setMembers] = useState<Profile[]>([]);
+  const { profile, members, householdName, loading } = usePageData();
   const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(null);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
-  const [householdName, setHouseholdName] = useState("家族タスク");
-  const [loading, setLoading] = useState(true);
 
   // Indicator refs for swipe ↔ tab sync
   const indicatorBarRef = useRef<HTMLDivElement>(null);
@@ -59,75 +55,6 @@ export default function Home() {
     if (!selectedCategoryId) return allTasks;
     return allTasks.filter((t) => t.category_id === selectedCategoryId);
   }, [allTasks, selectedCategoryId]);
-
-  useEffect(() => {
-    const load = async () => {
-      const supabase = createClient();
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-
-      if (!user) {
-        router.push("/login");
-        setLoading(false);
-        return;
-      }
-
-      const { data: profileData, error: profileError } = await supabase
-        .from("profiles")
-        .select("*")
-        .eq("id", user.id)
-        .maybeSingle();
-
-      if (profileError) toast.error("プロフィールの取得に失敗しました");
-
-      let profile = profileData;
-      if (!profile) {
-        const { data: created } = await supabase
-          .from("profiles")
-          .upsert({ id: user.id, nickname: user.user_metadata?.nickname ?? "" })
-          .select()
-          .single();
-        profile = created;
-      }
-
-      if (!profile) {
-        setLoading(false);
-        return;
-      }
-      if (!profile.household_id) {
-        setProfile(profile);
-        router.push("/household/new");
-        setLoading(false);
-        return;
-      }
-
-      // setProfile を先に呼ぶ → useTasks/useCategories が即座にフェッチ開始
-      setProfile(profile);
-
-      // メンバー取得・ハウスホールド名取得はバックグラウンドで並行（画面表示をブロックしない）
-      supabase
-        .from("profiles")
-        .select("*")
-        .eq("household_id", profile.household_id)
-        .then(({ data, error }) => {
-          if (error) toast.error("メンバーの取得に失敗しました");
-          if (data) setMembers(data);
-        });
-
-      supabase
-        .from("households")
-        .select("name")
-        .eq("id", profile.household_id)
-        .single()
-        .then(({ data }) => {
-          if (data?.name) setHouseholdName(data.name);
-        });
-
-      setLoading(false);
-    };
-    load();
-  }, [router]);
 
   if (loading) {
     return (

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -1,69 +1,24 @@
 "use client";
 
-import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { ArrowLeft, LogOut } from "lucide-react";
-import { toast } from "sonner";
 import { createClient } from "@/lib/supabase/client";
 import { ProfileEditor } from "@/components/settings/profile-editor";
 import { HouseholdSettings } from "@/components/settings/household-settings";
 import { CategorySettings } from "@/components/settings/category-settings";
 import { NotificationSettings } from "@/components/settings/notification-settings";
 import { useCategories } from "@/hooks/use-categories";
-import type { Profile, Household } from "@/types";
+import { usePageData } from "@/hooks/use-page-data";
 
 export default function SettingsPage() {
   const router = useRouter();
-  const [profile, setProfile] = useState<Profile | null>(null);
-  const [household, setHousehold] = useState<Household | null>(null);
-  const [members, setMembers] = useState<Profile[]>([]);
+  const { profile, setProfile, members, household, setHousehold } = usePageData({
+    redirectIfNoHousehold: false,
+    fetchHousehold: true,
+  });
   const { categories, addCategory, updateCategory, deleteCategory } = useCategories(
     profile?.household_id ?? null
   );
-
-  useEffect(() => {
-    const load = async () => {
-      const supabase = createClient();
-      const {
-        data: { user },
-      } = await supabase.auth.getUser();
-      if (!user) return;
-
-      const { data: p, error: profileError } = await supabase
-        .from("profiles")
-        .select("*")
-        .eq("id", user.id)
-        .maybeSingle();
-      if (profileError) toast.error("プロフィールの取得に失敗しました");
-      if (!p) return;
-
-      // setProfile を先に呼ぶ → useCategories が即座にフェッチ開始
-      setProfile(p);
-
-      if (p.household_id) {
-        // household と members を並列取得 (P3-4: N+1クエリ並列化)
-        const [householdResult, membersResult] = await Promise.all([
-          supabase
-            .from("households")
-            .select("*")
-            .eq("id", p.household_id)
-            .single(),
-          supabase
-            .from("profiles")
-            .select("*")
-            .eq("household_id", p.household_id)
-            .order("created_at", { ascending: true }),
-        ]);
-
-        if (householdResult.error) toast.error("ハウスホールドの取得に失敗しました");
-        if (householdResult.data) setHousehold(householdResult.data);
-
-        if (membersResult.error) toast.error("メンバーの取得に失敗しました");
-        if (membersResult.data) setMembers(membersResult.data);
-      }
-    };
-    load();
-  }, []);
 
   const handleLogout = async () => {
     const supabase = createClient();

--- a/src/components/task/category-picker.tsx
+++ b/src/components/task/category-picker.tsx
@@ -1,0 +1,53 @@
+"use client";
+
+import type { Category } from "@/types";
+
+interface CategoryPickerProps {
+  categories: Category[];
+  selectedId: string | null;
+  onChange: (id: string | null) => void;
+  showNone?: boolean;
+  label?: string;
+}
+
+export function CategoryPicker({
+  categories,
+  selectedId,
+  onChange,
+  showNone = false,
+  label,
+}: CategoryPickerProps) {
+  return (
+    <div>
+      {label && (
+        <label className="text-xs font-medium text-gray-500 mb-1.5 block">{label}</label>
+      )}
+      <div className="flex flex-wrap gap-1.5">
+        {showNone && (
+          <button
+            type="button"
+            onClick={() => onChange(null)}
+            className={`rounded-full px-3 py-1 text-xs font-medium ${
+              selectedId === null ? "bg-gray-800 text-white" : "bg-gray-100 text-gray-600"
+            }`}
+          >
+            なし
+          </button>
+        )}
+        {categories.map((cat) => (
+          <button
+            key={cat.id}
+            type="button"
+            onClick={() => onChange(selectedId === cat.id && !showNone ? null : cat.id)}
+            className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
+              selectedId === cat.id ? "text-white" : "bg-gray-100 text-gray-600"
+            }`}
+            style={selectedId === cat.id ? { backgroundColor: cat.color } : undefined}
+          >
+            {cat.name}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/task/quick-date-picker.tsx
+++ b/src/components/task/quick-date-picker.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { getQuickDate } from "@/lib/date";
+
+interface QuickDatePickerProps {
+  value: string;
+  onChange: (date: string) => void;
+  showClear?: boolean;
+  label?: string;
+}
+
+export function QuickDatePicker({
+  value,
+  onChange,
+  showClear = false,
+  label,
+}: QuickDatePickerProps) {
+  return (
+    <div>
+      {label && (
+        <label className="text-xs font-medium text-gray-500 mb-1.5 block">{label}</label>
+      )}
+      <div className="flex gap-2">
+        <button
+          type="button"
+          onClick={() => onChange(getQuickDate(0))}
+          className="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-200"
+        >
+          今日
+        </button>
+        <button
+          type="button"
+          onClick={() => onChange(getQuickDate(1))}
+          className="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-200"
+        >
+          明日
+        </button>
+        <input
+          type="date"
+          value={value}
+          onChange={(e) => onChange(e.target.value)}
+          className="flex-1 rounded-lg border border-gray-300 px-3 py-1 text-sm outline-none focus:border-indigo-500"
+        />
+        {showClear && value && (
+          <button
+            type="button"
+            onClick={() => onChange("")}
+            className="text-xs text-gray-400 hover:text-gray-600"
+          >
+            クリア
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/task/task-create-sheet.tsx
+++ b/src/components/task/task-create-sheet.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect } from "react";
 import { BottomSheet } from "@/components/ui/bottom-sheet";
 import { Button } from "@/components/ui/button";
+import { CategoryPicker } from "@/components/task/category-picker";
+import { QuickDatePicker } from "@/components/task/quick-date-picker";
 import type { Category } from "@/types";
 
 interface TaskCreateSheetProps {
@@ -52,12 +54,6 @@ export function TaskCreateSheet({
     onClose();
   };
 
-  const setQuickDate = (offset: number) => {
-    const d = new Date();
-    d.setDate(d.getDate() + offset);
-    setDueDate(d.toISOString().split("T")[0]);
-  };
-
   return (
     <BottomSheet isOpen={isOpen} onClose={onClose} title="タスクを追加">
       <form onSubmit={handleSubmit} className="flex flex-col gap-4">
@@ -70,54 +66,13 @@ export function TaskCreateSheet({
           autoFocus
         />
 
-        {/* Category selector */}
-        <div className="flex flex-wrap gap-1.5">
-          {categories.map((cat) => (
-            <button
-              key={cat.id}
-              type="button"
-              onClick={() => setCategoryId(categoryId === cat.id ? null : cat.id)}
-              className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-                categoryId === cat.id
-                  ? "text-white"
-                  : "bg-gray-100 text-gray-600"
-              }`}
-              style={
-                categoryId === cat.id
-                  ? { backgroundColor: cat.color }
-                  : undefined
-              }
-            >
-              {cat.name}
-            </button>
-          ))}
-        </div>
+        <CategoryPicker
+          categories={categories}
+          selectedId={categoryId}
+          onChange={setCategoryId}
+        />
 
-        {/* Due date */}
-        <div className="flex flex-col gap-2">
-          <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={() => setQuickDate(0)}
-              className="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-200"
-            >
-              今日
-            </button>
-            <button
-              type="button"
-              onClick={() => setQuickDate(1)}
-              className="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-200"
-            >
-              明日
-            </button>
-            <input
-              type="date"
-              value={dueDate}
-              onChange={(e) => setDueDate(e.target.value)}
-              className="flex-1 rounded-lg border border-gray-300 px-3 py-1 text-sm outline-none focus:border-indigo-500"
-            />
-          </div>
-        </div>
+        <QuickDatePicker value={dueDate} onChange={setDueDate} />
 
         {/* Memo */}
         <textarea

--- a/src/components/task/task-detail-modal.tsx
+++ b/src/components/task/task-detail-modal.tsx
@@ -5,6 +5,9 @@ import { Modal } from "@/components/ui/modal";
 import { Button } from "@/components/ui/button";
 import { ExternalLink, Trash2 } from "lucide-react";
 import type { Task, Category, Profile } from "@/types";
+import { isValidUrl } from "@/lib/validation";
+import { CategoryPicker } from "@/components/task/category-picker";
+import { QuickDatePicker } from "@/components/task/quick-date-picker";
 
 interface TaskDetailModalProps {
   task: Task | null;
@@ -14,15 +17,6 @@ interface TaskDetailModalProps {
   members: Profile[];
   onUpdate: (id: string, updates: Partial<Task>) => void;
   onDelete: (id: string) => void;
-}
-
-function isValidUrl(value: string): boolean {
-  try {
-    const parsed = new URL(value);
-    return ["http:", "https:"].includes(parsed.protocol);
-  } catch {
-    return false;
-  }
 }
 
 export function TaskDetailModal({
@@ -74,12 +68,6 @@ export function TaskDetailModal({
     onClose();
   };
 
-  const setQuickDate = (offset: number) => {
-    const d = new Date();
-    d.setDate(d.getDate() + offset);
-    setDueDate(d.toISOString().split("T")[0]);
-  };
-
   const createdByMember = members.find((m) => m.id === task.created_by);
 
   return (
@@ -94,69 +82,21 @@ export function TaskDetailModal({
         />
 
         {/* Category */}
-        <div>
-          <label className="text-xs font-medium text-gray-500 mb-1.5 block">カテゴリ</label>
-          <div className="flex flex-wrap gap-1.5">
-            <button
-              type="button"
-              onClick={() => setCategoryId(null)}
-              className={`rounded-full px-3 py-1 text-xs font-medium ${
-                categoryId === null ? "bg-gray-800 text-white" : "bg-gray-100 text-gray-600"
-              }`}
-            >
-              なし
-            </button>
-            {categories.map((cat) => (
-              <button
-                key={cat.id}
-                type="button"
-                onClick={() => setCategoryId(cat.id)}
-                className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-                  categoryId === cat.id ? "text-white" : "bg-gray-100 text-gray-600"
-                }`}
-                style={categoryId === cat.id ? { backgroundColor: cat.color } : undefined}
-              >
-                {cat.name}
-              </button>
-            ))}
-          </div>
-        </div>
+        <CategoryPicker
+          categories={categories}
+          selectedId={categoryId}
+          onChange={setCategoryId}
+          showNone
+          label="カテゴリ"
+        />
 
         {/* Due date */}
-        <div>
-          <label className="text-xs font-medium text-gray-500 mb-1.5 block">期限</label>
-          <div className="flex gap-2">
-            <button
-              type="button"
-              onClick={() => setQuickDate(0)}
-              className="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-200"
-            >
-              今日
-            </button>
-            <button
-              type="button"
-              onClick={() => setQuickDate(1)}
-              className="rounded-full bg-gray-100 px-3 py-1 text-xs font-medium text-gray-600 hover:bg-gray-200"
-            >
-              明日
-            </button>
-            <input
-              type="date"
-              value={dueDate}
-              onChange={(e) => setDueDate(e.target.value)}
-              className="flex-1 rounded-lg border border-gray-300 px-3 py-1 text-sm outline-none focus:border-indigo-500"
-            />
-            {dueDate && (
-              <button
-                type="button"
-                onClick={() => setDueDate("")}
-                className="text-xs text-gray-400 hover:text-gray-600"
-              >
-                クリア
-              </button>
-            )}
-          </div>
-        </div>
+        <QuickDatePicker
+          value={dueDate}
+          onChange={setDueDate}
+          showClear
+          label="期限"
+        />
 
         {/* Memo */}
         <div>

--- a/src/components/task/task-item.tsx
+++ b/src/components/task/task-item.tsx
@@ -6,6 +6,7 @@ import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
 import { Check, Calendar, GripVertical } from "lucide-react";
 import type { Task, Category, Profile } from "@/types";
+import { formatDueDate } from "@/lib/date";
 
 interface TaskItemProps {
   task: Task;
@@ -84,20 +85,6 @@ export function TaskItem({
   const sortStyle = {
     transform: CSS.Transform.toString(transform),
     transition: sortTransition,
-  };
-
-  const formatDueDate = (date: string) => {
-    const d = new Date(date);
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    const tomorrow = new Date(today);
-    tomorrow.setDate(tomorrow.getDate() + 1);
-    const target = new Date(d);
-    target.setHours(0, 0, 0, 0);
-
-    if (target.getTime() === today.getTime()) return "今日";
-    if (target.getTime() === tomorrow.getTime()) return "明日";
-    return `${d.getMonth() + 1}/${d.getDate()}`;
   };
 
   const isOverdue = task.due_date && !task.is_done && new Date(task.due_date) < new Date(new Date().toDateString());

--- a/src/hooks/use-page-data.ts
+++ b/src/hooks/use-page-data.ts
@@ -1,0 +1,129 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { toast } from "sonner";
+import { createClient } from "@/lib/supabase/client";
+import type { Profile, Household } from "@/types";
+
+interface UsePageDataOptions {
+  redirectIfNoHousehold?: boolean;
+  fetchHousehold?: boolean;
+}
+
+interface PageData {
+  profile: Profile | null;
+  setProfile: (p: Profile | null) => void;
+  members: Profile[];
+  household: Household | null;
+  setHousehold: (h: Household | null) => void;
+  householdName: string;
+  loading: boolean;
+}
+
+export function usePageData(options: UsePageDataOptions = {}): PageData {
+  const { redirectIfNoHousehold = true, fetchHousehold = false } = options;
+  const router = useRouter();
+  const [profile, setProfile] = useState<Profile | null>(null);
+  const [members, setMembers] = useState<Profile[]>([]);
+  const [household, setHousehold] = useState<Household | null>(null);
+  const [householdName, setHouseholdName] = useState("家族タスク");
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    const load = async () => {
+      const supabase = createClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      if (!user) {
+        router.push("/login");
+        setLoading(false);
+        return;
+      }
+
+      const { data: profileData, error: profileError } = await supabase
+        .from("profiles")
+        .select("*")
+        .eq("id", user.id)
+        .maybeSingle();
+
+      if (profileError) toast.error("プロフィールの取得に失敗しました");
+
+      let p = profileData;
+      if (!p) {
+        const { data: created } = await supabase
+          .from("profiles")
+          .upsert({ id: user.id, nickname: user.user_metadata?.nickname ?? "" })
+          .select()
+          .single();
+        p = created;
+      }
+
+      if (!p) {
+        setLoading(false);
+        return;
+      }
+
+      if (!p.household_id && redirectIfNoHousehold) {
+        setProfile(p);
+        router.push("/household/new");
+        setLoading(false);
+        return;
+      }
+
+      setProfile(p);
+
+      if (p.household_id) {
+        if (fetchHousehold) {
+          const [householdResult, membersResult] = await Promise.all([
+            supabase
+              .from("households")
+              .select("*")
+              .eq("id", p.household_id)
+              .single(),
+            supabase
+              .from("profiles")
+              .select("*")
+              .eq("household_id", p.household_id)
+              .order("created_at", { ascending: true }),
+          ]);
+
+          if (householdResult.error) toast.error("ハウスホールドの取得に失敗しました");
+          if (householdResult.data) {
+            setHousehold(householdResult.data);
+            if (householdResult.data.name) setHouseholdName(householdResult.data.name);
+          }
+
+          if (membersResult.error) toast.error("メンバーの取得に失敗しました");
+          if (membersResult.data) setMembers(membersResult.data);
+        } else {
+          // ホーム画面: メンバー・名前をバックグラウンドで取得（画面表示をブロックしない）
+          supabase
+            .from("profiles")
+            .select("*")
+            .eq("household_id", p.household_id)
+            .then(({ data, error }) => {
+              if (error) toast.error("メンバーの取得に失敗しました");
+              if (data) setMembers(data);
+            });
+
+          supabase
+            .from("households")
+            .select("name")
+            .eq("id", p.household_id)
+            .single()
+            .then(({ data }) => {
+              if (data?.name) setHouseholdName(data.name);
+            });
+        }
+      }
+
+      setLoading(false);
+    };
+    load();
+  }, [router, redirectIfNoHousehold, fetchHousehold]);
+
+  return { profile, setProfile, members, household, setHousehold, householdName, loading };
+}

--- a/src/hooks/use-tasks.ts
+++ b/src/hooks/use-tasks.ts
@@ -3,6 +3,7 @@
 import { useState, useEffect, useCallback } from "react";
 import { toast } from "sonner";
 import { createClient } from "@/lib/supabase/client";
+import { sendPushNotification } from "@/lib/push";
 import type { Task } from "@/types";
 
 export function useTasks(householdId: string | null) {
@@ -75,16 +76,11 @@ export function useTasks(householdId: string | null) {
     } else if (data) {
       // Update optimistic task with server data (ID is already the same)
       setTasks((prev) => prev.map((t) => (t.id === taskId ? data : t)));
-      // Send push notification (fire-and-forget)
-      fetch("/api/push/send", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          title: "家族タスク",
-          body: `「${data.title}」が追加されました`,
-          householdId: householdId,
-        }),
-      }).catch(() => {});
+      sendPushNotification({
+        title: "家族タスク",
+        body: `「${data.title}」が追加されました`,
+        householdId,
+      });
     }
     return { data, error };
   };
@@ -142,17 +138,12 @@ export function useTasks(householdId: string | null) {
     const task = tasks.find((t) => t.id === id);
     if (!task) return;
     const result = await updateTask(id, { is_done: !task.is_done });
-    // Send push notification when task is completed (fire-and-forget)
     if (!task.is_done && result?.data) {
-      fetch("/api/push/send", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          title: "家族タスク",
-          body: `「${task.title}」が完了しました`,
-          householdId: householdId,
-        }),
-      }).catch(() => {});
+      sendPushNotification({
+        title: "家族タスク",
+        body: `「${task.title}」が完了しました`,
+        householdId: householdId!,
+      });
     }
     return result;
   };

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,23 @@
+/**
+ * 日付ユーティリティ
+ */
+
+export function formatDueDate(date: string): string {
+  const d = new Date(date);
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const tomorrow = new Date(today);
+  tomorrow.setDate(tomorrow.getDate() + 1);
+  const target = new Date(d);
+  target.setHours(0, 0, 0, 0);
+
+  if (target.getTime() === today.getTime()) return "今日";
+  if (target.getTime() === tomorrow.getTime()) return "明日";
+  return `${d.getMonth() + 1}/${d.getDate()}`;
+}
+
+export function getQuickDate(offsetDays: number): string {
+  const d = new Date();
+  d.setDate(d.getDate() + offsetDays);
+  return d.toISOString().split("T")[0];
+}

--- a/src/lib/push.ts
+++ b/src/lib/push.ts
@@ -1,0 +1,19 @@
+/**
+ * プッシュ通知ヘルパー (fire-and-forget)
+ */
+
+export function sendPushNotification(params: {
+  title: string;
+  body: string;
+  householdId: string;
+}): void {
+  fetch("/api/push/send", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({
+      title: params.title,
+      body: params.body,
+      householdId: params.householdId,
+    }),
+  }).catch(() => {});
+}

--- a/src/lib/validation.ts
+++ b/src/lib/validation.ts
@@ -1,0 +1,12 @@
+/**
+ * バリデーションユーティリティ
+ */
+
+export function isValidUrl(value: string): boolean {
+  try {
+    const parsed = new URL(value);
+    return ["http:", "https:"].includes(parsed.protocol);
+  } catch {
+    return false;
+  }
+}


### PR DESCRIPTION
## Summary
- `lib/date.ts`, `lib/validation.ts`, `lib/push.ts` に散在していたユーティリティを抽出
- `CategoryPicker`, `QuickDatePicker` 共通コンポーネントで2箇所の重複UIを解消
- `usePageData` フックで `page.tsx` と `settings/page.tsx` の認証・データ取得ロジックを共通化
- `page.tsx` 232→159行、`settings/page.tsx` 125→89行に簡素化

## Test plan
- [ ] タスク作成 → カテゴリ選択 → 日付ピッカー → 保存が動作すること
- [ ] タスク詳細 → 編集 → カテゴリ変更 → 日付変更 → 保存が動作すること
- [ ] ホーム画面・設定画面の認証リダイレクトが動作すること
- [ ] `npm run build` が成功すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)