### PR TITLE
perf: フロントエンドパフォーマンス改善

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -56,6 +56,19 @@ export default function Home() {
     return allTasks.filter((t) => t.category_id === selectedCategoryId);
   }, [allTasks, selectedCategoryId]);
 
+  const handleTap = useCallback((task: Task) => setSelectedTask(task), []);
+  const handleDeleteTask = useCallback(async (id: string) => { await deleteTask(id); }, [deleteTask]);
+  const handleCloseCreate = useCallback(() => setIsCreateOpen(false), []);
+  const handleSubmit = useCallback(async (task: { title: string; category_id?: string | null; due_date?: string | null; memo?: string | null; url?: string | null }) => {
+    await addTask({ ...task, created_by: profile?.id ?? null });
+  }, [addTask, profile?.id]);
+  const handleCloseDetail = useCallback(() => setSelectedTask(null), []);
+  const handleUpdate = useCallback(async (id: string, updates: Partial<Task>) => { await updateTask(id, updates); }, [updateTask]);
+  const handleDeleteAllDone = useCallback(async () => {
+    const doneIds = tasks.filter((t) => t.is_done).map((t) => t.id);
+    await Promise.all(doneIds.map((id) => deleteTask(id)));
+  }, [tasks, deleteTask]);
+
   if (loading) {
     return (
       <div className="flex min-h-dvh items-center justify-center">
@@ -67,7 +80,7 @@ export default function Home() {
   return (
     <div className="min-h-dvh bg-gray-50">
       {/* Header */}
-      <header className="sticky top-0 z-30 bg-white/80 backdrop-blur-md border-b border-gray-100">
+      <header className="sticky top-0 z-30 bg-white/95 border-b border-gray-100">
         <div className="flex items-center justify-between px-4 py-3">
           <h1 className="text-lg font-bold text-gray-900">{householdName}</h1>
           <div className="flex items-center gap-2">
@@ -115,13 +128,10 @@ export default function Home() {
               categories={categories}
               members={members}
               onToggle={toggleTask}
-              onTap={(task) => setSelectedTask(task)}
-              onDelete={async (id) => { await deleteTask(id); }}
+              onTap={handleTap}
+              onDelete={handleDeleteTask}
               onReorder={reorderTasks}
-              onDeleteAllDone={async () => {
-                const doneIds = tasks.filter((t) => t.is_done).map((t) => t.id);
-                await Promise.all(doneIds.map((id) => deleteTask(id)));
-              }}
+              onDeleteAllDone={handleDeleteAllDone}
             />
           )}
         </SwipeableTaskContainer>
@@ -133,26 +143,21 @@ export default function Home() {
       {/* Create Sheet */}
       <TaskCreateSheet
         isOpen={isCreateOpen}
-        onClose={() => setIsCreateOpen(false)}
+        onClose={handleCloseCreate}
         categories={categories}
         selectedCategoryId={selectedCategoryId}
-        onSubmit={async (task) => {
-          await addTask({
-            ...task,
-            created_by: profile?.id ?? null,
-          });
-        }}
+        onSubmit={handleSubmit}
       />
 
       {/* Detail Modal */}
       <TaskDetailModal
         task={selectedTask}
         isOpen={!!selectedTask}
-        onClose={() => setSelectedTask(null)}
+        onClose={handleCloseDetail}
         categories={categories}
         members={members}
-        onUpdate={async (id, updates) => { await updateTask(id, updates); }}
-        onDelete={async (id) => { await deleteTask(id); }}
+        onUpdate={handleUpdate}
+        onDelete={handleDeleteTask}
       />
     </div>
   );

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -29,7 +29,7 @@ export default function SettingsPage() {
 
   return (
     <div className="min-h-dvh bg-gray-50">
-      <header className="sticky top-0 z-30 flex items-center gap-3 bg-white/80 backdrop-blur-md border-b border-gray-100 px-4 py-3">
+      <header className="sticky top-0 z-30 flex items-center gap-3 bg-white/95 border-b border-gray-100 px-4 py-3">
         <button onClick={() => router.back()} className="text-gray-600">
           <ArrowLeft size={24} />
         </button>

--- a/src/components/task/task-item.tsx
+++ b/src/components/task/task-item.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, memo } from "react";
 import { motion } from "framer-motion";
 import { useSortable } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
@@ -20,7 +20,7 @@ interface TaskItemProps {
   isOverlay?: boolean;
 }
 
-export function TaskItem({
+export const TaskItem = memo(function TaskItem({
   task,
   category,
   createdBy,
@@ -96,10 +96,9 @@ export function TaskItem({
   return (
     <div ref={setNodeRef} style={sortStyle} data-task-item>
       <motion.div
-        layout
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: isDragging ? 0.4 : 1, y: 0 }}
-        exit={{ opacity: 0, height: 0, marginBottom: 0 }}
+        exit={{ opacity: 0, scale: 0.95 }}
         transition={{ type: "spring", damping: 20, stiffness: 300 }}
         className="relative overflow-hidden rounded-lg"
         style={isOverlay ? { opacity: 0.9, boxShadow: "0 8px 24px rgba(0,0,0,0.15)" } : {}}
@@ -184,4 +183,4 @@ export function TaskItem({
       </motion.div>
     </div>
   );
-}
+});

--- a/src/components/task/task-list.tsx
+++ b/src/components/task/task-list.tsx
@@ -14,7 +14,6 @@ import {
   useSensors,
 } from "@dnd-kit/core";
 import { SortableContext, verticalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
-import confetti from "canvas-confetti";
 import { Trash2 } from "lucide-react";
 import { TaskItem } from "./task-item";
 import type { Task, Category, Profile } from "@/types";
@@ -51,7 +50,9 @@ export function TaskList({
     if (tasks.length > 0 && tasks.every((t) => t.is_done)) {
       if (!allDoneRef.current) {
         allDoneRef.current = true;
-        confetti({ particleCount: 100, spread: 70, origin: { y: 0.6 } });
+        import("canvas-confetti").then((mod) => {
+          mod.default({ particleCount: 100, spread: 70, origin: { y: 0.6 } });
+        });
       }
     } else {
       allDoneRef.current = false;

--- a/src/hooks/use-categories.ts
+++ b/src/hooks/use-categories.ts
@@ -1,17 +1,17 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { toast } from "sonner";
 import { createClient } from "@/lib/supabase/client";
 import type { Category } from "@/types";
 
 export function useCategories(householdId: string | null) {
+  const supabase = useMemo(() => createClient(), []);
   const [categories, setCategories] = useState<Category[]>([]);
   const [loading, setLoading] = useState(true);
 
   const fetchCategories = useCallback(async () => {
     if (!householdId) return;
-    const supabase = createClient();
     const { data, error } = await supabase
       .from("categories")
       .select("*")
@@ -21,7 +21,7 @@ export function useCategories(householdId: string | null) {
     if (error) toast.error("カテゴリの取得に失敗しました");
     if (data) setCategories(data);
     setLoading(false);
-  }, [householdId]);
+  }, [householdId, supabase]);
 
   useEffect(() => {
     fetchCategories();
@@ -29,7 +29,6 @@ export function useCategories(householdId: string | null) {
 
   const addCategory = async (name: string, color: string) => {
     if (!householdId) return;
-    const supabase = createClient();
     const sortOrder = categories.length;
     const { data, error } = await supabase
       .from("categories")
@@ -45,7 +44,6 @@ export function useCategories(householdId: string | null) {
   };
 
   const updateCategory = async (id: string, updates: Partial<Pick<Category, "name" | "color" | "icon" | "sort_order">>) => {
-    const supabase = createClient();
     const { error } = await supabase
       .from("categories")
       .update(updates)
@@ -61,7 +59,6 @@ export function useCategories(householdId: string | null) {
   };
 
   const deleteCategory = async (id: string) => {
-    const supabase = createClient();
     const { error } = await supabase.from("categories").delete().eq("id", id);
 
     if (error) toast.error("カテゴリの削除に失敗しました");

--- a/src/hooks/use-swipeable-tab.ts
+++ b/src/hooks/use-swipeable-tab.ts
@@ -30,6 +30,7 @@ export function useSwipeableTab({
   const currentDx = useRef(0);
   const swiping = useRef(false);
   const directionLocked = useRef<"horizontal" | "vertical" | null>(null);
+  const cachedContainerWidth = useRef(375);
 
   // Keep latest values in refs to avoid stale closures in event handlers
   const activeIndexRef = useRef(activeIndex);
@@ -98,6 +99,7 @@ export function useSwipeableTab({
     const container = containerRef.current;
     if (container) {
       container.style.transition = "";
+      cachedContainerWidth.current = container.offsetWidth;
     }
   }, [containerRef]);
 
@@ -140,7 +142,7 @@ export function useSwipeableTab({
     }
 
     // Update indicator
-    const containerWidth = container?.offsetWidth ?? 375;
+    const containerWidth = cachedContainerWidth.current;
     const progress = effectiveDx / containerWidth;
     // progress > 0 means swiping right (going to prev), < 0 means swiping left (going to next)
     // For indicator: positive progress = moving toward previous tab
@@ -157,7 +159,7 @@ export function useSwipeableTab({
     const dx = currentDx.current;
     const elapsed = Date.now() - startTime.current;
     const velocity = Math.abs(dx) / elapsed; // px/ms
-    const containerWidth = container?.offsetWidth ?? 375;
+    const containerWidth = cachedContainerWidth.current;
 
     const shouldSwipe = velocity > 0.3 || Math.abs(dx) > containerWidth * 0.3;
     const idx = activeIndexRef.current;

--- a/src/hooks/use-tasks.ts
+++ b/src/hooks/use-tasks.ts
@@ -1,18 +1,18 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useMemo } from "react";
 import { toast } from "sonner";
 import { createClient } from "@/lib/supabase/client";
 import { sendPushNotification } from "@/lib/push";
 import type { Task } from "@/types";
 
 export function useTasks(householdId: string | null) {
+  const supabase = useMemo(() => createClient(), []);
   const [tasks, setTasks] = useState<Task[]>([]);
   const [loading, setLoading] = useState(true);
 
   const fetchTasks = useCallback(async () => {
     if (!householdId) return;
-    const supabase = createClient();
 
     const { data, error } = await supabase
       .from("tasks")
@@ -25,7 +25,7 @@ export function useTasks(householdId: string | null) {
     if (error) toast.error("タスクの取得に失敗しました");
     if (data) setTasks(data);
     setLoading(false);
-  }, [householdId]);
+  }, [householdId, supabase]);
 
   useEffect(() => {
     fetchTasks();
@@ -62,7 +62,6 @@ export function useTasks(householdId: string | null) {
 
     setTasks((prev) => [optimisticTask, ...prev]);
 
-    const supabase = createClient();
     const { data, error } = await supabase
       .from("tasks")
       .insert({ id: taskId, ...task, household_id: householdId })
@@ -99,7 +98,6 @@ export function useTasks(householdId: string | null) {
       prev.map((t) => (t.id === id ? { ...t, ...updates } : t))
     );
 
-    const supabase = createClient();
     const { data, error } = await supabase
       .from("tasks")
       .update(updates)
@@ -123,7 +121,6 @@ export function useTasks(householdId: string | null) {
     const previousTasks = tasks;
     setTasks((prev) => prev.filter((t) => t.id !== id));
 
-    const supabase = createClient();
     const { error } = await supabase.from("tasks").delete().eq("id", id);
 
     if (error) {
@@ -157,7 +154,6 @@ export function useTasks(householdId: string | null) {
       return [...reordered, ...rest];
     });
 
-    const supabase = createClient();
     const { error } = await supabase.rpc("reorder_tasks", {
       p_task_ids: orderedIds,
       p_sort_orders: orderedIds.map((_, i) => i),


### PR DESCRIPTION
- TaskItem を React.memo でラップし不要な再レンダーを抑制
- page.tsx のインラインコールバックを useCallback 化
- TaskItem の exit アニメーションを transform ベース (scale) に変更し layout prop を削除
- useSwipeableTab で offsetWidth を touchstart 時にキャッシュしレイアウトスラッシングを解消
- ヘッダーの backdrop-blur-md を除去しスクロール時の再ペイントを軽減
- canvas-confetti を動的インポートに変更しバンドルサイズを削減
- useTasks/useCategories で createClient() をフック先頭で一元化