### PR TITLE
security: アプリ全体のセキュリティ強化

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -20,6 +20,20 @@ const nextConfig: NextConfig = {
             key: "Strict-Transport-Security",
             value: "max-age=63072000; includeSubDomains; preload",
           },
+          {
+            key: "Content-Security-Policy",
+            value: [
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval'",
+              "style-src 'self' 'unsafe-inline'",
+              "img-src 'self' data: blob: https:",
+              "font-src 'self'",
+              "connect-src 'self' https://*.supabase.co wss://*.supabase.co",
+              "frame-ancestors 'none'",
+              "base-uri 'self'",
+              "form-action 'self'",
+            ].join("; "),
+          },
         ],
       },
     ];

--- a/public/sw.js
+++ b/public/sw.js
@@ -18,7 +18,9 @@ self.addEventListener("fetch", () => {
 
 self.addEventListener("notificationclick", (event) => {
   event.notification.close();
-  const url = event.notification.data?.url || "/";
+  const rawUrl = event.notification.data?.url || "/";
+  // Only allow relative paths starting with / (prevent open redirect)
+  const url = typeof rawUrl === "string" && rawUrl.startsWith("/") && !rawUrl.startsWith("//") ? rawUrl : "/";
   event.waitUntil(
     clients
       .matchAll({ type: "window", includeUncontrolled: true })

--- a/src/app/api/push/send/route.ts
+++ b/src/app/api/push/send/route.ts
@@ -78,6 +78,10 @@ export async function POST(request: Request) {
     );
   }
 
+  // Truncate title/body to prevent abuse
+  const sanitizedTitle = String(title).slice(0, 200);
+  const sanitizedBody = String(body).slice(0, 500);
+
   // P2-4: Verify sender belongs to the requested household
   const { data: senderProfile } = await supabase
     .from("profiles")
@@ -114,7 +118,7 @@ export async function POST(request: Request) {
     return NextResponse.json({ success: true, sent: 0 });
   }
 
-  const payload = JSON.stringify({ title, body, url: "/" });
+  const payload = JSON.stringify({ title: sanitizedTitle, body: sanitizedBody, url: "/" });
 
   const results = await Promise.allSettled(
     subscriptions.map(async (sub) => {

--- a/src/app/api/push/subscribe/route.ts
+++ b/src/app/api/push/subscribe/route.ts
@@ -29,6 +29,39 @@ export async function POST(request: Request) {
     );
   }
 
+  // SSRF protection: only allow https endpoints, block private IPs
+  try {
+    const endpointUrl = new URL(endpoint);
+    if (endpointUrl.protocol !== "https:") {
+      return NextResponse.json(
+        { error: "Endpoint must use HTTPS" },
+        { status: 400 }
+      );
+    }
+    // Block private/internal hostnames
+    const hostname = endpointUrl.hostname;
+    if (
+      hostname === "localhost" ||
+      hostname.startsWith("127.") ||
+      hostname.startsWith("10.") ||
+      hostname.startsWith("192.168.") ||
+      hostname.startsWith("172.") ||
+      hostname === "0.0.0.0" ||
+      hostname.endsWith(".local") ||
+      hostname === "[::1]"
+    ) {
+      return NextResponse.json(
+        { error: "Invalid endpoint" },
+        { status: 400 }
+      );
+    }
+  } catch {
+    return NextResponse.json(
+      { error: "Invalid endpoint URL" },
+      { status: 400 }
+    );
+  }
+
   const { error } = await supabase.from("push_subscriptions").upsert(
     {
       profile_id: user.id,

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -4,7 +4,9 @@ import { createClient } from "@/lib/supabase/server";
 export async function GET(request: Request) {
   const { searchParams, origin } = new URL(request.url);
   const code = searchParams.get("code");
-  const next = searchParams.get("next") ?? "/";
+  const nextParam = searchParams.get("next") ?? "/";
+  // Validate redirect target: must be a relative path, not a protocol-relative URL
+  const next = nextParam.startsWith("/") && !nextParam.startsWith("//") ? nextParam : "/";
 
   if (code) {
     const supabase = await createClient();

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -67,9 +67,9 @@ export function LoginForm() {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           required
-          minLength={6}
+          minLength={8}
           className="rounded-lg border border-gray-300 px-4 py-3 text-base outline-none transition-colors focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20"
-          placeholder="6文字以上"
+          placeholder="8文字以上"
         />
         <div className="flex justify-end">
           <Link href="/forgot-password" className="text-xs text-indigo-600 hover:text-indigo-500">

--- a/src/components/auth/reset-password-form.tsx
+++ b/src/components/auth/reset-password-form.tsx
@@ -20,8 +20,8 @@ export function ResetPasswordForm() {
       return;
     }
 
-    if (password.length < 6) {
-      setError("パスワードは6文字以上で入力してください。");
+    if (password.length < 8) {
+      setError("パスワードは8文字以上で入力してください。");
       return;
     }
 
@@ -30,7 +30,7 @@ export function ResetPasswordForm() {
     const { error } = await supabase.auth.updateUser({ password });
 
     if (error) {
-      setError(error.message);
+      setError("パスワードの更新に失敗しました。もう一度お試しください。");
       setLoading(false);
       return;
     }
@@ -56,9 +56,9 @@ export function ResetPasswordForm() {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           required
-          minLength={6}
+          minLength={8}
           className="rounded-lg border border-gray-300 px-4 py-3 text-base outline-none transition-colors focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20"
-          placeholder="6文字以上"
+          placeholder="8文字以上"
         />
       </div>
       <div className="flex flex-col gap-1.5">
@@ -71,9 +71,9 @@ export function ResetPasswordForm() {
           value={confirm}
           onChange={(e) => setConfirm(e.target.value)}
           required
-          minLength={6}
+          minLength={8}
           className="rounded-lg border border-gray-300 px-4 py-3 text-base outline-none transition-colors focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20"
-          placeholder="6文字以上"
+          placeholder="8文字以上"
         />
       </div>
       <button

--- a/src/components/auth/signup-form.tsx
+++ b/src/components/auth/signup-form.tsx
@@ -30,7 +30,8 @@ export function SignupForm() {
     });
 
     if (error) {
-      setError(error.message);
+      // Don't expose raw Supabase error messages to users
+      setError("アカウントの作成に失敗しました。入力内容をご確認ください。");
       setLoading(false);
       return;
     }
@@ -133,9 +134,9 @@ export function SignupForm() {
           value={password}
           onChange={(e) => setPassword(e.target.value)}
           required
-          minLength={6}
+          minLength={8}
           className="rounded-lg border border-gray-300 px-4 py-3 text-base outline-none transition-colors focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20"
-          placeholder="6文字以上"
+          placeholder="8文字以上"
         />
       </div>
       <button

--- a/src/components/household/join-form.tsx
+++ b/src/components/household/join-form.tsx
@@ -26,15 +26,11 @@ export function JoinHouseholdForm() {
       return;
     }
 
-    // Find household by invite code
-    const { data: household, error: hError } = await supabase
-      .from("households")
-      .select()
-      .eq("invite_code", code.toUpperCase())
-      .gt("invite_code_expires_at", new Date().toISOString())
-      .single();
+    // Verify invite code via secure RPC (households table is no longer directly readable)
+    const { data: householdId, error: hError } = await supabase
+      .rpc("verify_invite_code", { p_code: code.toUpperCase() });
 
-    if (hError || !household) {
+    if (hError || !householdId) {
       setError("招待コードが無効か期限切れです");
       setLoading(false);
       return;
@@ -43,7 +39,7 @@ export function JoinHouseholdForm() {
     // Link profile to household
     const { error: pError } = await supabase
       .from("profiles")
-      .update({ household_id: household.id })
+      .update({ household_id: householdId })
       .eq("id", user.id);
 
     if (pError) {

--- a/src/hooks/use-tasks.ts
+++ b/src/hooks/use-tasks.ts
@@ -92,6 +92,18 @@ export function useTasks(householdId: string | null) {
       updates.completed_at = null;
     }
 
+    // Whitelist allowed fields to prevent unintended column updates
+    const allowedFields = [
+      "title", "memo", "url", "due_date", "is_done", "completed_at",
+      "category_id", "sort_order",
+    ] as const;
+    const sanitized: Record<string, unknown> = {};
+    for (const key of allowedFields) {
+      if (key in updates) {
+        sanitized[key] = updates[key as keyof Task];
+      }
+    }
+
     // Optimistic update
     const previousTasks = tasks;
     setTasks((prev) =>
@@ -100,7 +112,7 @@ export function useTasks(householdId: string | null) {
 
     const { data, error } = await supabase
       .from("tasks")
-      .update(updates)
+      .update(sanitized)
       .eq("id", id)
       .select()
       .single();

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -291,6 +291,10 @@ export type Database = {
         Args: { p_task_ids: string[]; p_sort_orders: number[] };
         Returns: undefined;
       };
+      verify_invite_code: {
+        Args: { p_code: string };
+        Returns: string;
+      };
     };
     Enums: Record<string, never>;
     CompositeTypes: Record<string, never>;

--- a/supabase/migrations/007_security_hardening.sql
+++ b/supabase/migrations/007_security_hardening.sql
@@ -1,0 +1,151 @@
+-- ============================================
+-- 007: セキュリティ強化
+-- ============================================
+-- CRITICAL: households SELECT ポリシーを制限（招待コード漏洩対策）
+-- HIGH: RPC 関数に所有権チェック追加
+-- HIGH: push_subscriptions SELECT ポリシーを自分のみに制限
+-- HIGH: reorder_tasks に配列ガード追加
+-- ============================================
+
+
+-- ============================================
+-- CRITICAL: households SELECT ポリシーを制限
+-- 現状 using(true) で全世帯の招待コードが漏洩
+-- → 自世帯のみ読み取り可 + 招待コード検証は RPC 経由
+-- ============================================
+
+-- 既存ポリシーを削除して再作成
+drop policy if exists "Household members can read" on public.households;
+
+-- 自世帯のみ読み取り可
+create policy "Household members can read own"
+  on public.households for select
+  using (id = public.get_my_household_id());
+
+-- 招待コード検証用 RPC（households テーブルを直接 SELECT しない）
+create or replace function public.verify_invite_code(p_code text)
+returns uuid
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_household_id uuid;
+begin
+  select id into v_household_id
+  from public.households
+  where invite_code = upper(p_code)
+    and invite_code_expires_at > now();
+
+  return v_household_id; -- NULL if not found
+end;
+$$;
+
+
+-- ============================================
+-- HIGH: generate_invite_code に所有権チェック追加
+-- 005 で再定義されたが set search_path = '' が脱落
+-- ============================================
+
+create or replace function public.generate_invite_code(p_household_id uuid)
+returns text
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_code text;
+begin
+  -- 呼び出し元が対象世帯のメンバーであることを確認
+  if p_household_id != public.get_my_household_id() then
+    raise exception 'Not a member of this household';
+  end if;
+
+  v_code := upper(encode(gen_random_bytes(8), 'hex'));
+  update public.households
+  set invite_code = v_code,
+      invite_code_expires_at = now() + interval '24 hours'
+  where id = p_household_id;
+  return v_code;
+end;
+$$;
+
+
+-- ============================================
+-- HIGH: create_default_categories に所有権チェック追加
+-- ============================================
+
+create or replace function public.create_default_categories(p_household_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  -- 呼び出し元が対象世帯のメンバーであることを確認
+  -- 新規世帯作成時は profile がまだ紐づいていない場合があるため、
+  -- profile の存在チェックのみ行う
+  if auth.uid() is null then
+    raise exception 'Authentication required';
+  end if;
+
+  -- 対象世帯にメンバーがいるか確認（新規作成者含む）
+  if not exists (
+    select 1 from public.profiles
+    where id = auth.uid()
+      and (household_id = p_household_id or household_id is null)
+  ) then
+    raise exception 'Not authorized for this household';
+  end if;
+
+  insert into public.categories (household_id, name, color, icon, sort_order) values
+    (p_household_id, '買い物', '#ef4444', 'shopping-cart', 0),
+    (p_household_id, '料理', '#f97316', 'chef-hat', 1),
+    (p_household_id, '掃除', '#22c55e', 'sparkles', 2),
+    (p_household_id, '洗濯', '#3b82f6', 'shirt', 3),
+    (p_household_id, 'その他', '#6366f1', 'list', 4);
+end;
+$$;
+
+
+-- ============================================
+-- HIGH: reorder_tasks に set search_path + 配列ガード追加
+-- ============================================
+
+create or replace function public.reorder_tasks(p_task_ids uuid[], p_sort_orders int[])
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+begin
+  -- 配列長の一致チェック
+  if array_length(p_task_ids, 1) != array_length(p_sort_orders, 1) then
+    raise exception 'Array length mismatch';
+  end if;
+
+  -- 上限ガード（DoS 対策）
+  if array_length(p_task_ids, 1) > 500 then
+    raise exception 'Too many tasks to reorder (max 500)';
+  end if;
+
+  update public.tasks
+  set sort_order = v.new_sort_order,
+      updated_at = now()
+  from unnest(p_task_ids, p_sort_orders) as v(task_id, new_sort_order)
+  where tasks.id = v.task_id
+    and tasks.household_id = public.get_my_household_id();
+end;
+$$;
+
+
+-- ============================================
+-- HIGH: push_subscriptions SELECT を自分のみに制限
+-- サーバー側 API は service_role で読むため問題なし
+-- ============================================
+
+drop policy if exists "Can read household member subscriptions" on public.push_subscriptions;
+
+create policy "Users can read own subscriptions"
+  on public.push_subscriptions for select
+  using (profile_id = auth.uid());


### PR DESCRIPTION
- CRITICAL: auth callback のオープンリダイレクト修正
- CRITICAL: households SELECT ポリシーを自世帯のみに制限 + verify_invite_code RPC 追加
- HIGH: generate_invite_code / create_default_categories に所有権チェック追加
- HIGH: reorder_tasks に search_path 設定 + 配列ガード追加
- HIGH: push subscribe エンドポイントの SSRF 対策（HTTPS 強制 + プライベート IP ブロック）
- HIGH: push_subscriptions SELECT を自分のみに制限
- MEDIUM: パスワード最小長を 8 文字に統一
- MEDIUM: CSP ヘッダー追加
- MEDIUM: updateTask フィールドホワイトリスト追加
- MEDIUM: push 通知 title/body 長さ制限
- MEDIUM: エラーメッセージの汎用化（Supabase 生メッセージ非表示）
- LOW: SW notificationclick URL バリデーション