### PR TITLE
Add drag-and-drop category reordering in settings

### DIFF
--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -16,7 +16,7 @@ export default function SettingsPage() {
     redirectIfNoHousehold: false,
     fetchHousehold: true,
   });
-  const { categories, addCategory, updateCategory, deleteCategory } = useCategories(
+  const { categories, addCategory, updateCategory, deleteCategory, reorderCategories } = useCategories(
     profile?.household_id ?? null
   );
 
@@ -64,6 +64,7 @@ export default function SettingsPage() {
             onAdd={async (name, color) => { await addCategory(name, color); }}
             onUpdate={async (id, updates) => { await updateCategory(id, updates); }}
             onDelete={async (id) => { await deleteCategory(id); }}
+            onReorder={async (ids) => { await reorderCategories(ids); }}
           />
         </div>
 

--- a/src/components/category/category-manager.tsx
+++ b/src/components/category/category-manager.tsx
@@ -1,7 +1,25 @@
 "use client";
 
 import { useState } from "react";
-import { Pencil, Trash2, Plus } from "lucide-react";
+import { Pencil, Trash2, Plus, GripVertical } from "lucide-react";
+import {
+  DndContext,
+  DragEndEvent,
+  DragOverlay,
+  DragStartEvent,
+  PointerSensor,
+  TouchSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  verticalListSortingStrategy,
+  arrayMove,
+  useSortable,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { Button } from "@/components/ui/button";
 import type { Category } from "@/types";
 
@@ -10,6 +28,7 @@ interface CategoryManagerProps {
   onAdd: (name: string, color: string) => Promise<void>;
   onUpdate: (id: string, updates: { name?: string; color?: string }) => Promise<void>;
   onDelete: (id: string) => Promise<void>;
+  onReorder: (orderedIds: string[]) => Promise<void>;
 }
 
 const PRESET_COLORS = [
@@ -17,11 +36,135 @@ const PRESET_COLORS = [
   "#3b82f6", "#6366f1", "#a855f7", "#ec4899",
 ];
 
-export function CategoryManager({ categories, onAdd, onUpdate, onDelete }: CategoryManagerProps) {
+interface SortableCategoryRowProps {
+  cat: Category;
+  editingId: string | null;
+  name: string;
+  color: string;
+  onNameChange: (v: string) => void;
+  onColorChange: (c: string) => void;
+  onStartEdit: (cat: Category) => void;
+  onUpdate: (id: string) => void;
+  onCancelEdit: () => void;
+  onDelete: (id: string) => void;
+}
+
+function SortableCategoryRow({
+  cat,
+  editingId,
+  name,
+  color,
+  onNameChange,
+  onColorChange,
+  onStartEdit,
+  onUpdate,
+  onCancelEdit,
+  onDelete,
+}: SortableCategoryRowProps) {
+  const isEditing = editingId === cat.id;
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: cat.id, disabled: isEditing });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : 1,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} className="flex items-center gap-2">
+      {isEditing ? (
+        <div className="flex flex-1 flex-col gap-2">
+          <input
+            value={name}
+            onChange={(e) => onNameChange(e.target.value)}
+            maxLength={50}
+            className="rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:border-indigo-500"
+            autoFocus
+          />
+          <div className="flex gap-1.5">
+            {PRESET_COLORS.map((c) => (
+              <button
+                key={c}
+                onClick={() => onColorChange(c)}
+                className={`h-6 w-6 rounded-full border-2 ${color === c ? "border-gray-800" : "border-transparent"}`}
+                style={{ backgroundColor: c }}
+              />
+            ))}
+          </div>
+          <div className="flex gap-2">
+            <Button size="sm" onClick={() => onUpdate(cat.id)}>保存</Button>
+            <Button size="sm" variant="ghost" onClick={onCancelEdit}>キャンセル</Button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <button
+            {...attributes}
+            {...listeners}
+            className="touch-none cursor-grab p-1 text-gray-300 hover:text-gray-500 active:cursor-grabbing shrink-0"
+            tabIndex={-1}
+          >
+            <GripVertical size={16} />
+          </button>
+          <div
+            className="h-4 w-4 rounded-full shrink-0"
+            style={{ backgroundColor: cat.color }}
+          />
+          <span className="flex-1 text-sm text-gray-900">{cat.name}</span>
+          <button onClick={() => onStartEdit(cat)} className="p-1 text-gray-400 hover:text-gray-600">
+            <Pencil size={16} />
+          </button>
+          <button onClick={() => onDelete(cat.id)} className="p-1 text-gray-400 hover:text-red-600">
+            <Trash2 size={16} />
+          </button>
+        </>
+      )}
+    </div>
+  );
+}
+
+function CategoryRowOverlay({ cat }: { cat: Category }) {
+  return (
+    <div className="flex items-center gap-2 rounded-lg bg-white px-2 py-1 shadow-lg opacity-90 border border-gray-100">
+      <GripVertical size={16} className="text-gray-400 shrink-0" />
+      <div className="h-4 w-4 rounded-full shrink-0" style={{ backgroundColor: cat.color }} />
+      <span className="flex-1 text-sm text-gray-900">{cat.name}</span>
+    </div>
+  );
+}
+
+export function CategoryManager({ categories, onAdd, onUpdate, onDelete, onReorder }: CategoryManagerProps) {
   const [isAdding, setIsAdding] = useState(false);
   const [editingId, setEditingId] = useState<string | null>(null);
   const [name, setName] = useState("");
   const [color, setColor] = useState(PRESET_COLORS[0]);
+  const [activeId, setActiveId] = useState<string | null>(null);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
+    useSensor(TouchSensor, { activationConstraint: { delay: 250, tolerance: 5 } })
+  );
+
+  const handleDragStart = (event: DragStartEvent) => {
+    setActiveId(event.active.id as string);
+  };
+
+  const handleDragEnd = async (event: DragEndEvent) => {
+    setActiveId(null);
+    const { active, over } = event;
+    if (!over || active.id === over.id) return;
+    const oldIndex = categories.findIndex((c) => c.id === active.id);
+    const newIndex = categories.findIndex((c) => c.id === over.id);
+    const reordered = arrayMove(categories, oldIndex, newIndex);
+    await onReorder(reordered.map((c) => c.id));
+  };
 
   const handleAdd = async () => {
     if (!name.trim()) return;
@@ -45,51 +188,37 @@ export function CategoryManager({ categories, onAdd, onUpdate, onDelete }: Categ
     setIsAdding(false);
   };
 
+  const activeCategory = activeId ? categories.find((c) => c.id === activeId) : null;
+
   return (
     <div className="flex flex-col gap-3">
-      {categories.map((cat) => (
-        <div key={cat.id} className="flex items-center gap-3">
-          {editingId === cat.id ? (
-            <div className="flex flex-1 flex-col gap-2">
-              <input
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                maxLength={50}
-                className="rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:border-indigo-500"
-                autoFocus
-              />
-              <div className="flex gap-1.5">
-                {PRESET_COLORS.map((c) => (
-                  <button
-                    key={c}
-                    onClick={() => setColor(c)}
-                    className={`h-6 w-6 rounded-full border-2 ${color === c ? "border-gray-800" : "border-transparent"}`}
-                    style={{ backgroundColor: c }}
-                  />
-                ))}
-              </div>
-              <div className="flex gap-2">
-                <Button size="sm" onClick={() => handleUpdate(cat.id)}>保存</Button>
-                <Button size="sm" variant="ghost" onClick={() => setEditingId(null)}>キャンセル</Button>
-              </div>
-            </div>
-          ) : (
-            <>
-              <div
-                className="h-4 w-4 rounded-full shrink-0"
-                style={{ backgroundColor: cat.color }}
-              />
-              <span className="flex-1 text-sm text-gray-900">{cat.name}</span>
-              <button onClick={() => startEdit(cat)} className="p-1 text-gray-400 hover:text-gray-600">
-                <Pencil size={16} />
-              </button>
-              <button onClick={() => onDelete(cat.id)} className="p-1 text-gray-400 hover:text-red-600">
-                <Trash2 size={16} />
-              </button>
-            </>
-          )}
-        </div>
-      ))}
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragStart={handleDragStart}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext items={categories.map((c) => c.id)} strategy={verticalListSortingStrategy}>
+          {categories.map((cat) => (
+            <SortableCategoryRow
+              key={cat.id}
+              cat={cat}
+              editingId={editingId}
+              name={name}
+              color={color}
+              onNameChange={setName}
+              onColorChange={setColor}
+              onStartEdit={startEdit}
+              onUpdate={handleUpdate}
+              onCancelEdit={() => setEditingId(null)}
+              onDelete={onDelete}
+            />
+          ))}
+        </SortableContext>
+        <DragOverlay>
+          {activeCategory ? <CategoryRowOverlay cat={activeCategory} /> : null}
+        </DragOverlay>
+      </DndContext>
 
       {isAdding ? (
         <div className="flex flex-col gap-2 rounded-lg border border-dashed border-gray-300 p-3">

--- a/src/components/settings/category-settings.tsx
+++ b/src/components/settings/category-settings.tsx
@@ -8,9 +8,10 @@ interface CategorySettingsProps {
   onAdd: (name: string, color: string) => Promise<void>;
   onUpdate: (id: string, updates: { name?: string; color?: string }) => Promise<void>;
   onDelete: (id: string) => Promise<void>;
+  onReorder: (orderedIds: string[]) => Promise<void>;
 }
 
-export function CategorySettings({ categories, onAdd, onUpdate, onDelete }: CategorySettingsProps) {
+export function CategorySettings({ categories, onAdd, onUpdate, onDelete, onReorder }: CategorySettingsProps) {
   return (
     <div className="flex flex-col gap-3">
       <h3 className="text-sm font-semibold text-gray-900">カテゴリ管理</h3>
@@ -19,6 +20,7 @@ export function CategorySettings({ categories, onAdd, onUpdate, onDelete }: Cate
         onAdd={onAdd}
         onUpdate={onUpdate}
         onDelete={onDelete}
+        onReorder={onReorder}
       />
     </div>
   );

--- a/src/hooks/use-categories.ts
+++ b/src/hooks/use-categories.ts
@@ -68,5 +68,21 @@ export function useCategories(householdId: string | null) {
     return { error };
   };
 
-  return { categories, loading, addCategory, updateCategory, deleteCategory, refetch: fetchCategories };
+  const reorderCategories = async (orderedIds: string[]) => {
+    setCategories((prev) => {
+      const map = new Map(prev.map((c) => [c.id, c]));
+      return orderedIds.map((id, i) => ({ ...map.get(id)!, sort_order: i }));
+    });
+    const results = await Promise.all(
+      orderedIds.map((id, i) =>
+        supabase.from("categories").update({ sort_order: i }).eq("id", id)
+      )
+    );
+    if (results.some((r) => r.error)) {
+      toast.error("カテゴリの並び替えに失敗しました");
+      fetchCategories();
+    }
+  };
+
+  return { categories, loading, addCategory, updateCategory, deleteCategory, reorderCategories, refetch: fetchCategories };
 }


### PR DESCRIPTION
Adds a GripVertical drag handle to each category row in the カテゴリ管理
settings section, allowing users to drag categories into any order. Uses
dnd-kit (already a project dependency) following the same pattern as task
reordering. Sort order is optimistically updated in state and persisted to
Supabase in parallel.

https://claude.ai/code/session_01LZAw52mX5XY8ekUFEKMNiz