### PR TITLE
fix: getQuickDate()のタイムゾーンバグを修正

### DIFF
--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -19,5 +19,8 @@ export function formatDueDate(date: string): string {
 export function getQuickDate(offsetDays: number): string {
   const d = new Date();
   d.setDate(d.getDate() + offsetDays);
-  return d.toISOString().split("T")[0];
+  const year = d.getFullYear();
+  const month = String(d.getMonth() + 1).padStart(2, "0");
+  const day = String(d.getDate()).padStart(2, "0");
+  return `${year}-${month}-${day}`;
 }


### PR DESCRIPTION
toISOString()はUTC日付を返すため、日本時間(UTC+9)の0〜8時台に
「今日」「明日」を選択すると前日の日付が保存される問題を修正。
ローカルの年月日を直接使うよう変更。

https://claude.ai/code/session_01TE7Lv8Jw5tzAzJ99WV1MdG