### PR TITLE
fix: AndroidのPWAアイコンが更新されない問題を修正

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -6,7 +6,7 @@ const nextConfig: NextConfig = {
       {
         // PWA assets: always revalidate so icon/manifest changes reach users immediately
         source:
-          "/(manifest\\.json|favicon\\.png|apple-touch-icon\\.png|icon-.*\\.png|icon-badge\\.png)",
+          "/(sw\\.js|manifest\\.json|favicon\\.png|apple-touch-icon\\.png|icon-.*\\.png|icon-badge\\.png)",
         headers: [{ key: "Cache-Control", value: "no-cache" }],
       },
       {

--- a/public/manifest.json
+++ b/public/manifest.json
@@ -9,49 +9,49 @@
   "orientation": "portrait",
   "icons": [
     {
-      "src": "/icon-48x48.png",
+      "src": "/icon-48x48.png?v=2",
       "sizes": "48x48",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "/icon-72x72.png",
+      "src": "/icon-72x72.png?v=2",
       "sizes": "72x72",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "/icon-96x96.png",
+      "src": "/icon-96x96.png?v=2",
       "sizes": "96x96",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "/icon-144x144.png",
+      "src": "/icon-144x144.png?v=2",
       "sizes": "144x144",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "/icon-192x192.png",
+      "src": "/icon-192x192.png?v=2",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "/icon-512x512.png",
+      "src": "/icon-512x512.png?v=2",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "/icon-maskable-192x192.png",
+      "src": "/icon-maskable-192x192.png?v=2",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "maskable"
     },
     {
-      "src": "/icon-maskable-512x512.png",
+      "src": "/icon-maskable-512x512.png?v=2",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const SW_VERSION = "2";
+const SW_VERSION = "3";
 
 self.addEventListener("install", () => {
   // Activate immediately without waiting for existing tabs to close


### PR DESCRIPTION
manifest.jsonのアイコンURLに?v=2を付加してChromeにマニフェスト変更を検知させ、
SW_VERSIONを3に更新してService Workerの再登録を促す。
またsw.jsをno-cacheヘッダー対象に追加。

https://claude.ai/code/session_016QerESxRUTMsE3MJnnurB6