### PR TITLE
fix: タスク更新時にパートナーへプッシュ通知を送信

### DIFF
--- a/src/hooks/use-tasks.test.ts
+++ b/src/hooks/use-tasks.test.ts
@@ -161,6 +161,44 @@ describe("useTasks", () => {
         expect.not.objectContaining({ household_id: "evil-household" })
       );
     });
+
+    it("更新成功時にプッシュ通知が送信される", async () => {
+      const { sendPushNotification } = await import("@/lib/push");
+      const task = makeTask({ id: "t-1", title: "掃除" });
+      chain._result = { data: [task], error: null };
+      const { result } = renderHook(() => useTasks(HOUSEHOLD_ID));
+      await waitFor(() => expect(result.current.tasks).toHaveLength(1));
+
+      const updatedTask = makeTask({ id: "t-1", title: "新しいタイトル" });
+      chain.single.mockResolvedValueOnce({ data: updatedTask, error: null });
+
+      await act(async () => {
+        await result.current.updateTask("t-1", { title: "新しいタイトル" });
+      });
+
+      expect(sendPushNotification).toHaveBeenCalledWith({
+        title: "家族タスク",
+        body: "「新しいタイトル」が更新されました",
+        householdId: HOUSEHOLD_ID,
+      });
+    });
+
+    it("skipNotification: true の場合は通知が送信されない", async () => {
+      const { sendPushNotification } = await import("@/lib/push");
+      vi.mocked(sendPushNotification).mockClear();
+      const task = makeTask({ id: "t-1" });
+      chain._result = { data: [task], error: null };
+      const { result } = renderHook(() => useTasks(HOUSEHOLD_ID));
+      await waitFor(() => expect(result.current.tasks).toHaveLength(1));
+
+      chain.single.mockResolvedValueOnce({ data: task, error: null });
+
+      await act(async () => {
+        await result.current.updateTask("t-1", { is_done: true }, { skipNotification: true });
+      });
+
+      expect(sendPushNotification).not.toHaveBeenCalled();
+    });
   });
 
   describe("deleteTask", () => {

--- a/src/hooks/use-tasks.ts
+++ b/src/hooks/use-tasks.ts
@@ -84,7 +84,7 @@ export function useTasks(householdId: string | null) {
     return { data, error };
   };
 
-  const updateTask = async (id: string, updates: Partial<Task>) => {
+  const updateTask = async (id: string, updates: Partial<Task>, options?: { skipNotification?: boolean }) => {
     // If marking as done, set completed_at
     if (updates.is_done === true) {
       updates.completed_at = new Date().toISOString();
@@ -124,6 +124,13 @@ export function useTasks(householdId: string | null) {
     } else if (data) {
       // Sync with server data
       setTasks((prev) => prev.map((t) => (t.id === id ? data : t)));
+      if (!options?.skipNotification && householdId) {
+        sendPushNotification({
+          title: "家族タスク",
+          body: `「${data.title}」が更新されました`,
+          householdId,
+        });
+      }
     }
     return { data, error };
   };
@@ -166,7 +173,7 @@ export function useTasks(householdId: string | null) {
   const toggleTask = async (id: string) => {
     const task = tasks.find((t) => t.id === id);
     if (!task) return;
-    const result = await updateTask(id, { is_done: !task.is_done });
+    const result = await updateTask(id, { is_done: !task.is_done }, { skipNotification: true });
     if (!task.is_done && result?.data) {
       sendPushNotification({
         title: "家族タスク",


### PR DESCRIPTION
updateTask にプッシュ通知ロジックが欠落していたため、タスク詳細モーダル
でのタイトル・カテゴリ・期限等の編集時にパートナーへ通知が送られなかった。

- updateTask 成功時に sendPushNotification を呼び出すよう追加
- toggleTask からの呼び出しでは skipNotification: true で二重送信を防止
- 通知送信・skipNotification のテストを追加

https://claude.ai/code/session_01MznypfhgDLawDRbJvaiu6E