### PR TITLE
fix: プッシュ通知送信で service_role を使い他メンバーの購読を取得

### DIFF
--- a/src/app/api/push/send/route.ts
+++ b/src/app/api/push/send/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse } from "next/server";
 import webpush from "web-push";
 import { createClient } from "@/lib/supabase/server";
+import { createServiceRoleClient } from "@/lib/supabase/service-role";
 
 let vapidConfigured = false;
 
@@ -96,8 +97,20 @@ export async function POST(request: Request) {
     );
   }
 
+  // push_subscriptions の SELECT は RLS で self のみ許可されているため、
+  // 他メンバーの購読を取得するにはサーバー側で service_role を使う必要がある。
+  let admin: ReturnType<typeof createServiceRoleClient>;
+  try {
+    admin = createServiceRoleClient();
+  } catch {
+    return NextResponse.json(
+      { error: "Push notifications not configured" },
+      { status: 500 }
+    );
+  }
+
   // Get push subscriptions for household members (excluding sender), filtered by household
-  const { data: householdMembers } = await supabase
+  const { data: householdMembers } = await admin
     .from("profiles")
     .select("id")
     .eq("household_id", householdId)
@@ -109,7 +122,7 @@ export async function POST(request: Request) {
 
   const memberIds = householdMembers.map((m) => m.id);
 
-  const { data: subscriptions } = await supabase
+  const { data: subscriptions } = await admin
     .from("push_subscriptions")
     .select("endpoint, p256dh, auth, profile_id")
     .in("profile_id", memberIds);
@@ -138,7 +151,7 @@ export async function POST(request: Request) {
           "statusCode" in err &&
           (err as { statusCode: number }).statusCode === 410
         ) {
-          await supabase
+          await admin
             .from("push_subscriptions")
             .delete()
             .eq("endpoint", sub.endpoint);

--- a/src/lib/supabase/service-role.ts
+++ b/src/lib/supabase/service-role.ts
@@ -1,0 +1,18 @@
+import { createClient as createSupabaseClient } from "@supabase/supabase-js";
+import type { Database } from "@/types/database";
+
+export function createServiceRoleClient() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url || !serviceRoleKey) {
+    throw new Error("SUPABASE_SERVICE_ROLE_KEY is not set");
+  }
+
+  return createSupabaseClient<Database>(url, serviceRoleKey, {
+    auth: {
+      persistSession: false,
+      autoRefreshToken: false,
+    },
+  });
+}


### PR DESCRIPTION
## Summary
- マイグレーション 007 (`fc04913`) で `push_subscriptions` の SELECT ポリシーを `profile_id = auth.uid()` に制限したが、`/api/push/send` は anon key の SSR クライアントのままだったため、他メンバーの購読行が RLS で弾かれて `sent=0` 固定になり通知が届かなかった。
- `src/lib/supabase/service-role.ts` を追加し、`/api/push/send` の購読取得と 410 時の削除のみ service_role に切り替え。認可（sender が `householdId` に所属しているか）は引き続き user クライアントで行いゲートを維持。
- RLS ポリシー（007 の設計意図＝購読の相互閲覧不可）は温存。マイグレーションの変更なし。

## 目的・背景
タスク追加／完了時に相手端末へ通知が届かなくなっていた障害の根本対応。原因は 007 の RLS 強化と API 実装側の service_role 未対応の不整合。

## 本番反映に必要な作業
- [ ] Vercel の Environment Variables に **`SUPABASE_SERVICE_ROLE_KEY`** を追加（Production/Preview/Development）。`NEXT_PUBLIC_` プレフィックスは付けない。
- [ ] 値は Supabase Dashboard → Settings → API Keys → `service_role` から取得。

## Test plan
- [ ] ローカル `.env.local` に `SUPABASE_SERVICE_ROLE_KEY` を設定（`npx supabase status` の値）。
- [ ] 2 アカウントで同一世帯にログインし、両方で通知購読 ON。
- [ ] 片方でタスク追加 → もう片方に「『◯◯』が追加されました」通知が届く。
- [ ] 片方でタスク完了 → もう片方に「『◯◯』が完了しました」通知が届く。
- [ ] `curl` で他世帯の `householdId` を指定して `/api/push/send` を叩き **403** が返る（認可ゲート健在）。
- [ ] `npm run build` 成功。

🤖 Generated with [Claude Code](https://claude.com/claude-code)