### PR TITLE
feat: 完了タスク全削除UIを確認モーダル+Undoトーストに改善

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -3,6 +3,8 @@
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
 import { Settings, ArrowUpDown, Check } from "lucide-react";
+import { toast } from "sonner";
+import { createClient } from "@/lib/supabase/client";
 import { CategoryTabs } from "@/components/category/category-tabs";
 import { TaskList } from "@/components/task/task-list";
 import { TaskListSkeleton } from "@/components/task/task-list-skeleton";
@@ -46,6 +48,7 @@ export default function Home() {
   }, []);
 
   const householdId = profile?.household_id ?? null;
+  const supabase = useMemo(() => createClient(), []);
   const { categories } = useCategories(householdId);
   const { tasks: allTasks, setTasks, loading: tasksLoading, addTask, updateTask, deleteTask, toggleTask, reorderTasks } =
     useTasks(householdId);
@@ -115,10 +118,44 @@ export default function Home() {
   }, [addTask, profile?.id, refetchRecommendations]);
 
   const handleDeleteAllDone = useCallback(async () => {
-    const doneIds = tasks.filter((t) => t.is_done).map((t) => t.id);
-    await Promise.all(doneIds.map((id) => deleteTask(id)));
+    const doneSnapshot = tasks.filter((t) => t.is_done);
+    if (doneSnapshot.length === 0) return;
+
+    const results = await Promise.all(
+      doneSnapshot.map((task) =>
+        deleteTask(task.id, { skipToast: true }).then((r) => ({ task, error: r?.error }))
+      )
+    );
+    const succeeded = results.filter((r) => !r.error).map((r) => r.task);
+    const failedCount = results.length - succeeded.length;
+
+    if (failedCount > 0) {
+      toast.error(`${failedCount}件の削除に失敗しました`);
+    }
+
+    if (succeeded.length > 0) {
+      toast(`完了済み${succeeded.length}件を削除しました`, {
+        action: {
+          label: "元に戻す",
+          onClick: () => {
+            supabase
+              .from("tasks")
+              .insert(succeeded)
+              .then(({ error }) => {
+                if (!error) {
+                  setTasks((prev) => [...succeeded, ...prev]);
+                } else {
+                  toast.error("元に戻せませんでした");
+                }
+              });
+          },
+        },
+        duration: 4000,
+      });
+    }
+
     refetchRecommendations();
-  }, [tasks, deleteTask, refetchRecommendations]);
+  }, [tasks, deleteTask, supabase, setTasks, refetchRecommendations]);
 
   return (
     <div className="min-h-dvh bg-gray-50">

--- a/src/components/task/task-list.tsx
+++ b/src/components/task/task-list.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useEffect, useRef, useState, useMemo, useCallback } from "react";
-import { AnimatePresence, motion } from "framer-motion";
+import { AnimatePresence } from "framer-motion";
 import {
   DndContext,
   DragEndEvent,
@@ -16,6 +16,7 @@ import {
 import { SortableContext, verticalListSortingStrategy, arrayMove } from "@dnd-kit/sortable";
 import { Trash2 } from "lucide-react";
 import { TaskItem } from "./task-item";
+import { ConfirmDialog } from "@/components/ui/confirm-dialog";
 import type { Task, Category, Profile } from "@/types";
 
 interface TaskListProps {
@@ -211,39 +212,23 @@ export function TaskList({
                 完了 ({doneTasks.length})
               </p>
               <button
+                type="button"
                 onClick={() => setShowConfirm(true)}
-                className="flex items-center gap-1 text-xs text-red-400 hover:text-red-600"
+                className="inline-flex min-h-[40px] items-center gap-1.5 rounded-full bg-red-50 px-3 py-2 text-sm font-medium text-red-600 transition-colors hover:bg-red-100"
               >
-                <Trash2 size={14} />
+                <Trash2 size={16} />
                 すべて削除
               </button>
             </div>
-            <AnimatePresence>
-              {showConfirm && (
-                <motion.div
-                  initial={{ opacity: 0, y: -8 }}
-                  animate={{ opacity: 1, y: 0 }}
-                  exit={{ opacity: 0, y: -8 }}
-                  className="flex items-center justify-between rounded-lg bg-red-50 px-3 py-2 text-sm"
-                >
-                  <span className="text-red-700">完了済み {doneTasks.length}件を削除しますか？</span>
-                  <div className="flex items-center gap-2">
-                    <button
-                      onClick={handleConfirmDelete}
-                      className="rounded bg-red-500 px-2 py-1 text-xs font-medium text-white hover:bg-red-600"
-                    >
-                      削除
-                    </button>
-                    <button
-                      onClick={() => setShowConfirm(false)}
-                      className="text-xs text-gray-500 hover:text-gray-700"
-                    >
-                      キャンセル
-                    </button>
-                  </div>
-                </motion.div>
-              )}
-            </AnimatePresence>
+            <ConfirmDialog
+              isOpen={showConfirm}
+              title="完了済みタスクを削除"
+              description={`${doneTasks.length}件の完了済みタスクを削除します。削除後は「元に戻す」から復元できます。`}
+              confirmLabel="削除する"
+              variant="destructive"
+              onConfirm={handleConfirmDelete}
+              onCancel={() => setShowConfirm(false)}
+            />
             <AnimatePresence mode="popLayout" initial={false}>
               {doneTasks.map((task) => (
                 <TaskItem

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { AnimatePresence, motion } from "framer-motion";
+
+interface ConfirmDialogProps {
+  isOpen: boolean;
+  title: string;
+  description?: string;
+  confirmLabel: string;
+  cancelLabel?: string;
+  variant?: "destructive" | "default";
+  onConfirm: () => void;
+  onCancel: () => void;
+}
+
+export function ConfirmDialog({
+  isOpen,
+  title,
+  description,
+  confirmLabel,
+  cancelLabel = "キャンセル",
+  variant = "default",
+  onConfirm,
+  onCancel,
+}: ConfirmDialogProps) {
+  const cancelButtonRef = useRef<HTMLButtonElement>(null);
+
+  useEffect(() => {
+    if (isOpen) {
+      document.body.style.overflow = "hidden";
+    } else {
+      document.body.style.overflow = "";
+    }
+    return () => {
+      document.body.style.overflow = "";
+    };
+  }, [isOpen]);
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === "Escape") {
+        e.preventDefault();
+        onCancel();
+      }
+    };
+    window.addEventListener("keydown", handleKeyDown);
+
+    const focusTimer = window.setTimeout(() => {
+      cancelButtonRef.current?.focus();
+    }, 50);
+
+    return () => {
+      window.removeEventListener("keydown", handleKeyDown);
+      window.clearTimeout(focusTimer);
+    };
+  }, [isOpen, onCancel]);
+
+  const confirmClass =
+    variant === "destructive"
+      ? "bg-red-500 hover:bg-red-600 text-white"
+      : "bg-indigo-500 hover:bg-indigo-600 text-white";
+
+  return (
+    <AnimatePresence>
+      {isOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center px-4"
+          role="dialog"
+          aria-modal="true"
+          aria-labelledby="confirm-dialog-title"
+          aria-describedby={description ? "confirm-dialog-description" : undefined}
+        >
+          <motion.div
+            className="absolute inset-0 bg-black/40"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: 1 }}
+            exit={{ opacity: 0 }}
+            onClick={onCancel}
+          />
+          <motion.div
+            className="relative w-full max-w-sm rounded-2xl bg-white p-5 shadow-xl"
+            initial={{ opacity: 0, scale: 0.95, y: 12 }}
+            animate={{ opacity: 1, scale: 1, y: 0 }}
+            exit={{ opacity: 0, scale: 0.95, y: 12 }}
+            transition={{ type: "spring", damping: 24, stiffness: 320 }}
+          >
+            <h2
+              id="confirm-dialog-title"
+              className="text-lg font-bold text-gray-900"
+            >
+              {title}
+            </h2>
+            {description && (
+              <p
+                id="confirm-dialog-description"
+                className="mt-2 text-sm leading-relaxed text-gray-600"
+              >
+                {description}
+              </p>
+            )}
+            <div className="mt-5 flex flex-col gap-2">
+              <button
+                type="button"
+                onClick={onConfirm}
+                className={`min-h-[48px] rounded-xl font-bold transition-colors ${confirmClass}`}
+              >
+                {confirmLabel}
+              </button>
+              <button
+                ref={cancelButtonRef}
+                type="button"
+                onClick={onCancel}
+                className="min-h-[48px] rounded-xl bg-gray-100 font-medium text-gray-800 transition-colors hover:bg-gray-200"
+              >
+                {cancelLabel}
+              </button>
+            </div>
+          </motion.div>
+        </div>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/src/hooks/use-tasks.ts
+++ b/src/hooks/use-tasks.ts
@@ -135,7 +135,7 @@ export function useTasks(householdId: string | null) {
     return { data, error };
   };
 
-  const deleteTask = async (id: string) => {
+  const deleteTask = async (id: string, options?: { skipToast?: boolean }) => {
     // Optimistic update: remove task immediately
     const previousTasks = tasks;
     const deletedTask = previousTasks.find((t) => t.id === id);
@@ -146,8 +146,10 @@ export function useTasks(householdId: string | null) {
     if (error) {
       // Rollback
       setTasks(previousTasks);
-      toast.error("タスクの削除に失敗しました");
-    } else if (deletedTask) {
+      if (!options?.skipToast) {
+        toast.error("タスクの削除に失敗しました");
+      }
+    } else if (deletedTask && !options?.skipToast) {
       toast("タスクを削除しました", {
         action: {
           label: "元に戻す",


### PR DESCRIPTION
インライン確認バーはタップ面積が狭く誤タップを誘発していた。以下
3点で操作性と安全性を引き上げる：

- 起点「すべて削除」ボタンをピル形・min-h 40px へ拡大
- 専用 ConfirmDialog コンポーネントを新設し、確認を明示化
  （縦積み2ボタン・min-h 48px・背景タップ/Escape でキャンセル）
- 削除後に集約 Undo トースト「完了済みN件を削除しました/元に戻す」
  を表示。N件分のトーストが重ならないよう deleteTask に
  skipToast オプションを追加し page.tsx 側で集約

単一タスク削除の Undo パターンと挙動を揃えた。