### PR TITLE
feat: Notion 風デザインシステムへ刷新

### DIFF
--- a/DESIGN.md
+++ b/DESIGN.md
@@ -1,0 +1,309 @@
+# Design System Inspired by Notion
+
+## 1. Visual Theme & Atmosphere
+
+Notion's website embodies the philosophy of the tool itself: a blank canvas that gets out of your way. The design system is built on warm neutrals rather than cold grays, creating a distinctly approachable minimalism that feels like quality paper rather than sterile glass. The page canvas is pure white (`#ffffff`) but the text isn't pure black -- it's a warm near-black (`rgba(0,0,0,0.95)`) that softens the reading experience imperceptibly. The warm gray scale (`#f6f5f4`, `#31302e`, `#615d59`, `#a39e98`) carries subtle yellow-brown undertones, giving the interface a tactile, almost analog warmth.
+
+The custom NotionInter font (a modified Inter) is the backbone of the system. At display sizes (64px), it uses aggressive negative letter-spacing (-2.125px), creating headlines that feel compressed and precise. The weight range is broader than typical systems: 400 for body, 500 for UI elements, 600 for semi-bold labels, and 700 for display headings. OpenType features `"lnum"` (lining numerals) and `"locl"` (localized forms) are enabled on larger text, adding typographic sophistication that rewards close reading.
+
+What makes Notion's visual language distinctive is its border philosophy. Rather than heavy borders or shadows, Notion uses ultra-thin `1px solid rgba(0,0,0,0.1)` borders -- borders that exist as whispers, barely perceptible division lines that create structure without weight. The shadow system is equally restrained: multi-layer stacks with cumulative opacity never exceeding 0.05, creating depth that's felt rather than seen.
+
+**Key Characteristics:**
+- NotionInter (modified Inter) with negative letter-spacing at display sizes (-2.125px at 64px)
+- Warm neutral palette: grays carry yellow-brown undertones (`#f6f5f4` warm white, `#31302e` warm dark)
+- Near-black text via `rgba(0,0,0,0.95)` -- not pure black, creating micro-warmth
+- Ultra-thin borders: `1px solid rgba(0,0,0,0.1)` throughout -- whisper-weight division
+- Multi-layer shadow stacks with sub-0.05 opacity for barely-there depth
+- Notion Blue (`#0075de`) as the singular accent color for CTAs and interactive elements
+- Pill badges (9999px radius) with tinted blue backgrounds for status indicators
+- 8px base spacing unit with an organic, non-rigid scale
+
+## 2. Color Palette & Roles
+
+### Primary
+- **Notion Black** (`rgba(0,0,0,0.95)` / `#000000f2`): Primary text, headings, body copy. The 95% opacity softens pure black without sacrificing readability.
+- **Pure White** (`#ffffff`): Page background, card surfaces, button text on blue.
+- **Notion Blue** (`#0075de`): Primary CTA, link color, interactive accent -- the only saturated color in the core UI chrome.
+
+### Brand Secondary
+- **Deep Navy** (`#213183`): Secondary brand color, used sparingly for emphasis and dark feature sections.
+- **Active Blue** (`#005bab`): Button active/pressed state -- darker variant of Notion Blue.
+
+### Warm Neutral Scale
+- **Warm White** (`#f6f5f4`): Background surface tint, section alternation, subtle card fill. The yellow undertone is key.
+- **Warm Dark** (`#31302e`): Dark surface background, dark section text. Warmer than standard grays.
+- **Warm Gray 500** (`#615d59`): Secondary text, descriptions, muted labels.
+- **Warm Gray 300** (`#a39e98`): Placeholder text, disabled states, caption text.
+
+### Semantic Accent Colors
+- **Teal** (`#2a9d99`): Success states, positive indicators.
+- **Green** (`#1aae39`): Confirmation, completion badges.
+- **Orange** (`#dd5b00`): Warning states, attention indicators.
+- **Pink** (`#ff64c8`): Decorative accent, feature highlights.
+- **Purple** (`#391c57`): Premium features, deep accents.
+- **Brown** (`#523410`): Earthy accent, warm feature sections.
+
+### Interactive
+- **Link Blue** (`#0075de`): Primary link color with underline-on-hover.
+- **Link Light Blue** (`#62aef0`): Lighter link variant for dark backgrounds.
+- **Focus Blue** (`#097fe8`): Focus ring on interactive elements.
+- **Badge Blue Bg** (`#f2f9ff`): Pill badge background, tinted blue surface.
+- **Badge Blue Text** (`#097fe8`): Pill badge text, darker blue for readability.
+
+### Shadows & Depth
+- **Card Shadow** (`rgba(0,0,0,0.04) 0px 4px 18px, rgba(0,0,0,0.027) 0px 2.025px 7.84688px, rgba(0,0,0,0.02) 0px 0.8px 2.925px, rgba(0,0,0,0.01) 0px 0.175px 1.04062px`): Multi-layer card elevation.
+- **Deep Shadow** (`rgba(0,0,0,0.01) 0px 1px 3px, rgba(0,0,0,0.02) 0px 3px 7px, rgba(0,0,0,0.02) 0px 7px 15px, rgba(0,0,0,0.04) 0px 14px 28px, rgba(0,0,0,0.05) 0px 23px 52px`): Five-layer deep elevation for modals and featured content.
+- **Whisper Border** (`1px solid rgba(0,0,0,0.1)`): Standard division border -- cards, dividers, sections.
+
+## 3. Typography Rules
+
+### Font Family
+- **Primary**: `NotionInter`, with fallbacks: `Inter, -apple-system, system-ui, Segoe UI, Helvetica, Apple Color Emoji, Arial, Segoe UI Emoji, Segoe UI Symbol`
+- **OpenType Features**: `"lnum"` (lining numerals) and `"locl"` (localized forms) enabled on display and heading text.
+
+### Hierarchy
+
+| Role | Font | Size | Weight | Line Height | Letter Spacing | Notes |
+|------|------|------|--------|-------------|----------------|-------|
+| Display Hero | NotionInter | 64px (4.00rem) | 700 | 1.00 (tight) | -2.125px | Maximum compression, billboard headlines |
+| Display Secondary | NotionInter | 54px (3.38rem) | 700 | 1.04 (tight) | -1.875px | Secondary hero, feature headlines |
+| Section Heading | NotionInter | 48px (3.00rem) | 700 | 1.00 (tight) | -1.5px | Feature section titles, with `"lnum"` |
+| Sub-heading Large | NotionInter | 40px (2.50rem) | 700 | 1.50 | normal | Card headings, feature sub-sections |
+| Sub-heading | NotionInter | 26px (1.63rem) | 700 | 1.23 (tight) | -0.625px | Section sub-titles, content headers |
+| Card Title | NotionInter | 22px (1.38rem) | 700 | 1.27 (tight) | -0.25px | Feature cards, list titles |
+| Body Large | NotionInter | 20px (1.25rem) | 600 | 1.40 | -0.125px | Introductions, feature descriptions |
+| Body | NotionInter | 16px (1.00rem) | 400 | 1.50 | normal | Standard reading text |
+| Body Medium | NotionInter | 16px (1.00rem) | 500 | 1.50 | normal | Navigation, emphasized UI text |
+| Body Semibold | NotionInter | 16px (1.00rem) | 600 | 1.50 | normal | Strong labels, active states |
+| Body Bold | NotionInter | 16px (1.00rem) | 700 | 1.50 | normal | Headlines at body size |
+| Nav / Button | NotionInter | 15px (0.94rem) | 600 | 1.33 | normal | Navigation links, button text |
+| Caption | NotionInter | 14px (0.88rem) | 500 | 1.43 | normal | Metadata, secondary labels |
+| Caption Light | NotionInter | 14px (0.88rem) | 400 | 1.43 | normal | Body captions, descriptions |
+| Badge | NotionInter | 12px (0.75rem) | 600 | 1.33 | 0.125px | Pill badges, tags, status labels |
+| Micro Label | NotionInter | 12px (0.75rem) | 400 | 1.33 | 0.125px | Small metadata, timestamps |
+
+### Principles
+- **Compression at scale**: NotionInter at display sizes uses -2.125px letter-spacing at 64px, progressively relaxing to -0.625px at 26px and normal at 16px. The compression creates density at headlines while maintaining readability at body sizes.
+- **Four-weight system**: 400 (body/reading), 500 (UI/interactive), 600 (emphasis/navigation), 700 (headings/display). The broader weight range compared to most systems allows nuanced hierarchy.
+- **Warm scaling**: Line height tightens as size increases -- 1.50 at body (16px), 1.23-1.27 at sub-headings, 1.00-1.04 at display. This creates denser, more impactful headlines.
+- **Badge micro-tracking**: The 12px badge text uses positive letter-spacing (0.125px) -- the only positive tracking in the system, creating wider, more legible small text.
+
+## 4. Component Stylings
+
+### Buttons
+
+**Primary Blue**
+- Background: `#0075de` (Notion Blue)
+- Text: `#ffffff`
+- Padding: 8px 16px
+- Radius: 4px (subtle)
+- Border: `1px solid transparent`
+- Hover: background darkens to `#005bab`
+- Active: scale(0.9) transform
+- Focus: `2px solid` focus outline, `var(--shadow-level-200)` shadow
+- Use: Primary CTA ("Get Notion free", "Try it")
+
+**Secondary / Tertiary**
+- Background: `rgba(0,0,0,0.05)` (translucent warm gray)
+- Text: `#000000` (near-black)
+- Padding: 8px 16px
+- Radius: 4px
+- Hover: text color shifts, scale(1.05)
+- Active: scale(0.9) transform
+- Use: Secondary actions, form submissions
+
+**Ghost / Link Button**
+- Background: transparent
+- Text: `rgba(0,0,0,0.95)`
+- Decoration: underline on hover
+- Use: Tertiary actions, inline links
+
+**Pill Badge Button**
+- Background: `#f2f9ff` (tinted blue)
+- Text: `#097fe8`
+- Padding: 4px 8px
+- Radius: 9999px (full pill)
+- Font: 12px weight 600
+- Use: Status badges, feature labels, "New" tags
+
+### Cards & Containers
+- Background: `#ffffff`
+- Border: `1px solid rgba(0,0,0,0.1)` (whisper border)
+- Radius: 12px (standard cards), 16px (featured/hero cards)
+- Shadow: `rgba(0,0,0,0.04) 0px 4px 18px, rgba(0,0,0,0.027) 0px 2.025px 7.84688px, rgba(0,0,0,0.02) 0px 0.8px 2.925px, rgba(0,0,0,0.01) 0px 0.175px 1.04062px`
+- Hover: subtle shadow intensification
+- Image cards: 12px top radius, image fills top half
+
+### Inputs & Forms
+- Background: `#ffffff`
+- Text: `rgba(0,0,0,0.9)`
+- Border: `1px solid #dddddd`
+- Padding: 6px
+- Radius: 4px
+- Focus: blue outline ring
+- Placeholder: warm gray `#a39e98`
+
+### Navigation
+- Clean horizontal nav on white, not sticky
+- Brand logo left-aligned (33x34px icon + wordmark)
+- Links: NotionInter 15px weight 500-600, near-black text
+- Hover: color shift to `var(--color-link-primary-text-hover)`
+- CTA: blue pill button ("Get Notion free") right-aligned
+- Mobile: hamburger menu collapse
+- Product dropdowns with multi-level categorized menus
+
+### Image Treatment
+- Product screenshots with `1px solid rgba(0,0,0,0.1)` border
+- Top-rounded images: `12px 12px 0px 0px` radius
+- Dashboard/workspace preview screenshots dominate feature sections
+- Warm gradient backgrounds behind hero illustrations (decorative character illustrations)
+
+### Distinctive Components
+
+**Feature Cards with Illustrations**
+- Large illustrative headers (The Great Wave, product UI screenshots)
+- 12px radius card with whisper border
+- Title at 22px weight 700, description at 16px weight 400
+- Warm white (`#f6f5f4`) background variant for alternating sections
+
+**Trust Bar / Logo Grid**
+- Company logos (trusted teams section) in their brand colors
+- Horizontal scroll or grid layout with team counts
+- Metric display: large number + description pattern
+
+**Metric Cards**
+- Large number display (e.g., "$4,200 ROI")
+- NotionInter 40px+ weight 700 for the metric
+- Description below in warm gray body text
+- Whisper-bordered card container
+
+## 5. Layout Principles
+
+### Spacing System
+- Base unit: 8px
+- Scale: 2px, 3px, 4px, 5px, 6px, 7px, 8px, 11px, 12px, 14px, 16px, 24px, 32px
+- Non-rigid organic scale with fractional values (5.6px, 6.4px) for micro-adjustments
+
+### Grid & Container
+- Max content width: approximately 1200px
+- Hero: centered single-column with generous top padding (80-120px)
+- Feature sections: 2-3 column grids for cards
+- Full-width warm white (`#f6f5f4`) section backgrounds for alternation
+- Code/dashboard screenshots as contained with whisper border
+
+### Whitespace Philosophy
+- **Generous vertical rhythm**: 64-120px between major sections. Notion lets content breathe with vast vertical padding.
+- **Warm alternation**: White sections alternate with warm white (`#f6f5f4`) sections, creating gentle visual rhythm without harsh color breaks.
+- **Content-first density**: Body text blocks are compact (line-height 1.50) but surrounded by ample margin, creating islands of readable content in a sea of white space.
+
+### Border Radius Scale
+- Micro (4px): Buttons, inputs, functional interactive elements
+- Subtle (5px): Links, list items, menu items
+- Standard (8px): Small cards, containers, inline elements
+- Comfortable (12px): Standard cards, feature containers, image tops
+- Large (16px): Hero cards, featured content, promotional blocks
+- Full Pill (9999px): Badges, pills, status indicators
+- Circle (100%): Tab indicators, avatars
+
+## 6. Depth & Elevation
+
+| Level | Treatment | Use |
+|-------|-----------|-----|
+| Flat (Level 0) | No shadow, no border | Page background, text blocks |
+| Whisper (Level 1) | `1px solid rgba(0,0,0,0.1)` | Standard borders, card outlines, dividers |
+| Soft Card (Level 2) | 4-layer shadow stack (max opacity 0.04) | Content cards, feature blocks |
+| Deep Card (Level 3) | 5-layer shadow stack (max opacity 0.05, 52px blur) | Modals, featured panels, hero elements |
+| Focus (Accessibility) | `2px solid var(--focus-color)` outline | Keyboard focus on all interactive elements |
+
+**Shadow Philosophy**: Notion's shadow system uses multiple layers with extremely low individual opacity (0.01 to 0.05) that accumulate into soft, natural-looking elevation. The 4-layer card shadow spans from 1.04px to 18px blur, creating a gradient of depth rather than a single hard shadow. The 5-layer deep shadow extends to 52px blur at 0.05 opacity, producing ambient occlusion that feels like natural light rather than computer-generated depth. This layered approach makes elements feel embedded in the page rather than floating above it.
+
+### Decorative Depth
+- Hero section: decorative character illustrations (playful, hand-drawn style)
+- Section alternation: white to warm white (`#f6f5f4`) background shifts
+- No hard section borders -- separation comes from background color changes and spacing
+
+## 7. Responsive Behavior
+
+### Breakpoints
+| Name | Width | Key Changes |
+|------|-------|-------------|
+| Mobile Small | <400px | Tight single column, minimal padding |
+| Mobile | 400-600px | Standard mobile, stacked layout |
+| Tablet Small | 600-768px | 2-column grids begin |
+| Tablet | 768-1080px | Full card grids, expanded padding |
+| Desktop Small | 1080-1200px | Standard desktop layout |
+| Desktop | 1200-1440px | Full layout, maximum content width |
+| Large Desktop | >1440px | Centered, generous margins |
+
+### Touch Targets
+- Buttons use comfortable padding (8px-16px vertical)
+- Navigation links at 15px with adequate spacing
+- Pill badges have 8px horizontal padding for tap targets
+- Mobile menu toggle uses standard hamburger button
+
+### Collapsing Strategy
+- Hero: 64px display -> scales to 40px -> 26px on mobile, maintains proportional letter-spacing
+- Navigation: horizontal links + blue CTA -> hamburger menu
+- Feature cards: 3-column -> 2-column -> single column stacked
+- Product screenshots: maintain aspect ratio with responsive images
+- Trust bar logos: grid -> horizontal scroll on mobile
+- Footer: multi-column -> stacked single column
+- Section spacing: 80px+ -> 48px on mobile
+
+### Image Behavior
+- Workspace screenshots maintain whisper border at all sizes
+- Hero illustrations scale proportionally
+- Product screenshots use responsive images with consistent border radius
+- Full-width warm white sections maintain edge-to-edge treatment
+
+## 8. Accessibility & States
+
+### Focus System
+- All interactive elements receive visible focus indicators
+- Focus outline: `2px solid` with focus color + shadow level 200
+- Tab navigation supported throughout all interactive components
+- High contrast text: near-black on white exceeds WCAG AAA (>14:1 ratio)
+
+### Interactive States
+- **Default**: Standard appearance with whisper borders
+- **Hover**: Color shift on text, scale(1.05) on buttons, underline on links
+- **Active/Pressed**: scale(0.9) transform, darker background variant
+- **Focus**: Blue outline ring with shadow reinforcement
+- **Disabled**: Warm gray (`#a39e98`) text, reduced opacity
+
+### Color Contrast
+- Primary text (rgba(0,0,0,0.95)) on white: ~18:1 ratio
+- Secondary text (#615d59) on white: ~5.5:1 ratio (WCAG AA)
+- Blue CTA (#0075de) on white: ~4.6:1 ratio (WCAG AA for large text)
+- Badge text (#097fe8) on badge bg (#f2f9ff): ~4.5:1 ratio (WCAG AA for large text)
+
+## 9. Agent Prompt Guide
+
+### Quick Color Reference
+- Primary CTA: Notion Blue (`#0075de`)
+- Background: Pure White (`#ffffff`)
+- Alt Background: Warm White (`#f6f5f4`)
+- Heading text: Near-Black (`rgba(0,0,0,0.95)`)
+- Body text: Near-Black (`rgba(0,0,0,0.95)`)
+- Secondary text: Warm Gray 500 (`#615d59`)
+- Muted text: Warm Gray 300 (`#a39e98`)
+- Border: `1px solid rgba(0,0,0,0.1)`
+- Link: Notion Blue (`#0075de`)
+- Focus ring: Focus Blue (`#097fe8`)
+
+### Example Component Prompts
+- "Create a hero section on white background. Headline at 64px NotionInter weight 700, line-height 1.00, letter-spacing -2.125px, color rgba(0,0,0,0.95). Subtitle at 20px weight 600, line-height 1.40, color #615d59. Blue CTA button (#0075de, 4px radius, 8px 16px padding, white text) and ghost button (transparent bg, near-black text, underline on hover)."
+- "Design a card: white background, 1px solid rgba(0,0,0,0.1) border, 12px radius. Use shadow stack: rgba(0,0,0,0.04) 0px 4px 18px, rgba(0,0,0,0.027) 0px 2.025px 7.85px, rgba(0,0,0,0.02) 0px 0.8px 2.93px, rgba(0,0,0,0.01) 0px 0.175px 1.04px. Title at 22px NotionInter weight 700, letter-spacing -0.25px. Body at 16px weight 400, color #615d59."
+- "Build a pill badge: #f2f9ff background, #097fe8 text, 9999px radius, 4px 8px padding, 12px NotionInter weight 600, letter-spacing 0.125px."
+- "Create navigation: white header. NotionInter 15px weight 600 for links, near-black text. Blue pill CTA 'Get Notion free' right-aligned (#0075de bg, white text, 4px radius)."
+- "Design an alternating section layout: white sections alternate with warm white (#f6f5f4) sections. Each section has 64-80px vertical padding, max-width 1200px centered. Section heading at 48px weight 700, line-height 1.00, letter-spacing -1.5px."
+
+### Iteration Guide
+1. Always use warm neutrals -- Notion's grays have yellow-brown undertones (#f6f5f4, #31302e, #615d59, #a39e98), never blue-gray
+2. Letter-spacing scales with font size: -2.125px at 64px, -1.875px at 54px, -0.625px at 26px, normal at 16px
+3. Four weights: 400 (read), 500 (interact), 600 (emphasize), 700 (announce)
+4. Borders are whispers: 1px solid rgba(0,0,0,0.1) -- never heavier
+5. Shadows use 4-5 layers with individual opacity never exceeding 0.05
+6. The warm white (#f6f5f4) section background is essential for visual rhythm
+7. Pill badges (9999px) for status/tags, 4px radius for buttons and inputs
+8. Notion Blue (#0075de) is the only saturated color in core UI -- use it sparingly for CTAs and links

--- a/src/app/error.tsx
+++ b/src/app/error.tsx
@@ -9,22 +9,22 @@ export default function Error({
   reset: () => void;
 }) {
   return (
-    <div className="flex min-h-dvh items-center justify-center bg-gray-50 px-4">
+    <div className="flex min-h-dvh items-center justify-center bg-background px-4">
       <div className="text-center">
-        <h1 className="text-xl font-bold text-gray-900">
+        <h1 className="text-xl font-bold tracking-tight text-foreground">
           問題が発生しました
         </h1>
-        <p className="mt-2 text-sm text-gray-500">
+        <p className="mt-2 text-sm text-muted">
           予期しないエラーが発生しました。再試行するか、ホームに戻ってください。
         </p>
         <div className="mt-6 flex flex-col items-center gap-3">
           <button
             onClick={() => reset()}
-            className="rounded-lg bg-[var(--primary)] px-6 py-2.5 text-sm font-semibold text-white"
+            className="rounded bg-primary px-6 py-2.5 text-sm font-semibold text-white hover:bg-primary-dark"
           >
             再試行
           </button>
-          <Link href="/" className="text-sm text-[var(--primary)] underline">
+          <Link href="/" className="text-sm text-primary underline">
             ホームに戻る
           </Link>
         </div>

--- a/src/app/forgot-password/page.tsx
+++ b/src/app/forgot-password/page.tsx
@@ -3,17 +3,17 @@ import { ForgotPasswordForm } from "@/components/auth/forgot-password-form";
 
 export default function ForgotPasswordPage() {
   return (
-    <div className="flex min-h-dvh items-center justify-center bg-gray-50 px-4">
+    <div className="flex min-h-dvh items-center justify-center bg-background px-4">
       <div className="w-full max-w-sm">
         <div className="mb-8 text-center">
-          <h1 className="text-2xl font-bold text-gray-900">パスワードリセット</h1>
-          <p className="mt-2 text-sm text-gray-600">
+          <h1 className="text-2xl font-bold tracking-tight text-foreground">パスワードリセット</h1>
+          <p className="mt-2 text-sm text-muted">
             登録済みのメールアドレスにリセット用リンクを送信します
           </p>
         </div>
         <ForgotPasswordForm />
-        <p className="mt-6 text-center text-sm text-gray-600">
-          <Link href="/login" className="font-medium text-indigo-600 hover:text-indigo-500">
+        <p className="mt-6 text-center text-sm text-muted">
+          <Link href="/login" className="font-medium text-primary hover:text-primary-dark">
             ログインに戻る
           </Link>
         </p>

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1,29 +1,87 @@
 @import "tailwindcss";
 
 :root {
-  --background: #f9fafb;
-  --foreground: #111827;
-  --primary: #6366f1;
-  --primary-light: #818cf8;
-  --primary-dark: #4f46e5;
+  /* Surfaces */
+  --background: #f6f5f4;
+  --surface: #ffffff;
+  --surface-strong: #ebeae8;
+
+  /* Text */
+  --foreground: #111111;
+  --text-muted: #615d59;
+  --text-subtle: #a39e98;
+
+  /* Borders */
+  --border: #e6e4e1;
+  --border-strong: #d6d3cf;
+
+  /* Brand */
+  --primary: #0075de;
+  --primary-dark: #005bab;
+  --primary-soft: #f2f9ff;
+  --focus: #097fe8;
+
+  /* Semantic — desaturated Notion tones */
+  --danger: #c4441e;
+  --warning: #dd5b00;
+  --caution: #a85420;
+  --success: #1aae39;
+
+  /* Elevation */
+  --shadow-card: 0 4px 18px rgba(0, 0, 0, 0.04),
+    0 2.025px 7.84688px rgba(0, 0, 0, 0.027),
+    0 0.8px 2.925px rgba(0, 0, 0, 0.02),
+    0 0.175px 1.04062px rgba(0, 0, 0, 0.01);
+  --shadow-deep: 0 1px 3px rgba(0, 0, 0, 0.01),
+    0 3px 7px rgba(0, 0, 0, 0.02),
+    0 7px 15px rgba(0, 0, 0, 0.02),
+    0 14px 28px rgba(0, 0, 0, 0.04),
+    0 23px 52px rgba(0, 0, 0, 0.05);
 }
 
 @theme inline {
   --color-background: var(--background);
+  --color-surface: var(--surface);
+  --color-surface-strong: var(--surface-strong);
   --color-foreground: var(--foreground);
+  --color-muted: var(--text-muted);
+  --color-subtle: var(--text-subtle);
+  --color-border: var(--border);
+  --color-border-strong: var(--border-strong);
   --color-primary: var(--primary);
-  --color-primary-light: var(--primary-light);
   --color-primary-dark: var(--primary-dark);
-  --font-sans: var(--font-geist-sans);
+  --color-primary-soft: var(--primary-soft);
+  --color-focus: var(--focus);
+  --color-danger: var(--danger);
+  --color-warning: var(--warning);
+  --color-caution: var(--caution);
+  --color-success: var(--success);
+
+  --font-sans: var(--font-inter);
   --font-mono: var(--font-geist-mono);
+
+  --shadow-notion-card: var(--shadow-card);
+  --shadow-notion-deep: var(--shadow-deep);
 }
 
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: var(--font-sans), -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  font-family: var(--font-sans), Inter, -apple-system, BlinkMacSystemFont,
+    "Segoe UI", Helvetica, Arial, sans-serif;
+  font-feature-settings: "lnum", "locl";
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
+}
+
+h1,
+h2,
+h3 {
+  letter-spacing: -0.02em;
+}
+
+h1 {
+  letter-spacing: -0.025em;
 }
 
 /* Hide scrollbar for category tabs */

--- a/src/app/household/join/page.tsx
+++ b/src/app/household/join/page.tsx
@@ -3,18 +3,18 @@ import { JoinHouseholdForm } from "@/components/household/join-form";
 
 export default function JoinHouseholdPage() {
   return (
-    <div className="flex min-h-dvh items-center justify-center bg-gray-50 px-4">
+    <div className="flex min-h-dvh items-center justify-center bg-background px-4">
       <div className="w-full max-w-sm">
         <div className="mb-8 text-center">
-          <h1 className="text-2xl font-bold text-gray-900">ハウスホールドに参加</h1>
-          <p className="mt-2 text-sm text-gray-600">
+          <h1 className="text-2xl font-bold tracking-tight text-foreground">ハウスホールドに参加</h1>
+          <p className="mt-2 text-sm text-muted">
             招待コードを入力してください
           </p>
         </div>
         <JoinHouseholdForm />
-        <p className="mt-6 text-center text-sm text-gray-600">
+        <p className="mt-6 text-center text-sm text-muted">
           新しく作成する場合は{" "}
-          <Link href="/household/new" className="font-medium text-indigo-600 hover:text-indigo-500">
+          <Link href="/household/new" className="font-medium text-primary hover:text-primary-dark">
             ハウスホールドを作成
           </Link>
         </p>

--- a/src/app/household/new/page.tsx
+++ b/src/app/household/new/page.tsx
@@ -3,18 +3,18 @@ import { CreateHouseholdForm } from "@/components/household/create-form";
 
 export default function NewHouseholdPage() {
   return (
-    <div className="flex min-h-dvh items-center justify-center bg-gray-50 px-4">
+    <div className="flex min-h-dvh items-center justify-center bg-background px-4">
       <div className="w-full max-w-sm">
         <div className="mb-8 text-center">
-          <h1 className="text-2xl font-bold text-gray-900">ハウスホールド作成</h1>
-          <p className="mt-2 text-sm text-gray-600">
+          <h1 className="text-2xl font-bold tracking-tight text-foreground">ハウスホールド作成</h1>
+          <p className="mt-2 text-sm text-muted">
             家族のグループを作りましょう
           </p>
         </div>
         <CreateHouseholdForm />
-        <p className="mt-6 text-center text-sm text-gray-600">
+        <p className="mt-6 text-center text-sm text-muted">
           招待コードをお持ちの方は{" "}
-          <Link href="/household/join" className="font-medium text-indigo-600 hover:text-indigo-500">
+          <Link href="/household/join" className="font-medium text-primary hover:text-primary-dark">
             参加する
           </Link>
         </p>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,11 @@
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
+import { Inter, Geist_Mono } from "next/font/google";
 import { ServiceWorkerRegister } from "@/components/ServiceWorkerRegister";
 import { Toaster } from "@/components/ui/toaster";
 import "./globals.css";
 
-const geistSans = Geist({
-  variable: "--font-geist-sans",
+const inter = Inter({
+  variable: "--font-inter",
   subsets: ["latin"],
 });
 
@@ -40,7 +40,7 @@ export const viewport: Viewport = {
   initialScale: 1,
   maximumScale: 1,
   userScalable: false,
-  themeColor: "#6366f1",
+  themeColor: "#ffffff",
   interactiveWidget: "resizes-content",
 };
 
@@ -52,7 +52,7 @@ export default function RootLayout({
   return (
     <html lang="ja">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${inter.variable} ${geistMono.variable} antialiased`}
       >
         <ServiceWorkerRegister />
         <Toaster />

--- a/src/app/login/page.tsx
+++ b/src/app/login/page.tsx
@@ -3,18 +3,18 @@ import { LoginForm } from "@/components/auth/login-form";
 
 export default function LoginPage() {
   return (
-    <div className="flex min-h-dvh items-center justify-center bg-gray-50 px-4">
+    <div className="flex min-h-dvh items-center justify-center bg-background px-4">
       <div className="w-full max-w-sm">
         <div className="mb-8 text-center">
-          <h1 className="text-2xl font-bold text-gray-900">ログイン</h1>
-          <p className="mt-2 text-sm text-gray-600">
+          <h1 className="text-2xl font-bold tracking-tight text-foreground">ログイン</h1>
+          <p className="mt-2 text-sm text-muted">
             家族タスク共有アプリへようこそ
           </p>
         </div>
         <LoginForm />
-        <p className="mt-6 text-center text-sm text-gray-600">
+        <p className="mt-6 text-center text-sm text-muted">
           アカウントをお持ちでない方は{" "}
-          <Link href="/signup" className="font-medium text-indigo-600 hover:text-indigo-500">
+          <Link href="/signup" className="font-medium text-primary hover:text-primary-dark">
             新規登録
           </Link>
         </p>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -2,19 +2,19 @@ import Link from "next/link";
 
 export default function NotFound() {
   return (
-    <div className="flex min-h-dvh items-center justify-center bg-gray-50 px-4">
+    <div className="flex min-h-dvh items-center justify-center bg-background px-4">
       <div className="text-center">
-        <p className="text-6xl font-bold text-[var(--primary)]">404</p>
-        <h1 className="mt-4 text-xl font-bold text-gray-900">
+        <p className="text-6xl font-bold tracking-tight text-primary">404</p>
+        <h1 className="mt-4 text-xl font-bold tracking-tight text-foreground">
           ページが見つかりません
         </h1>
-        <p className="mt-2 text-sm text-gray-500">
+        <p className="mt-2 text-sm text-muted">
           お探しのページは存在しないか、移動した可能性があります。
         </p>
         <div className="mt-6">
           <Link
             href="/"
-            className="inline-block rounded-lg bg-[var(--primary)] px-6 py-2.5 text-sm font-semibold text-white"
+            className="inline-block rounded bg-primary px-6 py-2.5 text-sm font-semibold text-white hover:bg-primary-dark"
           >
             ホームに戻る
           </Link>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -158,20 +158,20 @@ export default function Home() {
   }, [tasks, deleteTask, supabase, setTasks, refetchRecommendations]);
 
   return (
-    <div className="min-h-dvh bg-gray-50">
+    <div className="min-h-dvh bg-background">
       {/* Header */}
-      <header className="sticky top-0 z-30 bg-white/95 border-b border-gray-100">
+      <header className="sticky top-0 z-30 bg-surface/95 backdrop-blur border-b border-border">
         <div className="flex items-center justify-between px-4 py-3">
           {loading ? (
-            <div className="h-5 w-28 rounded bg-gray-200 animate-pulse" />
+            <div className="h-5 w-28 rounded bg-surface-strong animate-pulse" />
           ) : (
-            <h1 className="text-lg font-bold text-gray-900">{householdName}</h1>
+            <h1 className="text-lg font-bold tracking-tight text-foreground">{householdName}</h1>
           )}
           <div className="flex items-center gap-2">
             {loading ? (
               <>
-                <div className="h-7 w-7 rounded-full bg-gray-200 animate-pulse" />
-                <div className="h-7 w-7 rounded-full bg-gray-200 animate-pulse" />
+                <div className="h-7 w-7 rounded-full bg-surface-strong animate-pulse" />
+                <div className="h-7 w-7 rounded-full bg-surface-strong animate-pulse" />
               </>
             ) : (
               members.map((m) => (
@@ -180,14 +180,14 @@ export default function Home() {
             )}
             <button
               onClick={() => setIsSortOpen(true)}
-              className={`p-1.5 ${sortOption !== "manual" ? "text-indigo-500" : "text-gray-500 hover:text-gray-700"}`}
+              className={`p-1.5 ${sortOption !== "manual" ? "text-primary" : "text-muted hover:text-foreground"}`}
               aria-label="並び替え"
             >
               <ArrowUpDown size={20} />
             </button>
             <button
               onClick={() => router.push("/settings")}
-              className="ml-1 p-1.5 text-gray-500 hover:text-gray-700"
+              className="ml-1 p-1.5 text-muted hover:text-foreground"
             >
               <Settings size={20} />
             </button>
@@ -273,12 +273,12 @@ export default function Home() {
                 setSortOption(opt.value);
                 setIsSortOpen(false);
               }}
-              className="flex items-center justify-between rounded-lg px-4 py-3 text-left text-sm font-medium hover:bg-gray-50 active:bg-gray-100"
+              className="flex items-center justify-between rounded px-4 py-3 text-left text-sm font-medium hover:bg-surface-strong active:bg-border-strong"
             >
-              <span className={sortOption === opt.value ? "text-indigo-600" : "text-gray-800"}>
+              <span className={sortOption === opt.value ? "text-primary" : "text-foreground"}>
                 {opt.label}
               </span>
-              {sortOption === opt.value && <Check size={16} className="text-indigo-600 shrink-0" />}
+              {sortOption === opt.value && <Check size={16} className="text-primary shrink-0" />}
             </button>
           ))}
         </div>

--- a/src/app/reset-password/page.tsx
+++ b/src/app/reset-password/page.tsx
@@ -2,11 +2,11 @@ import { ResetPasswordForm } from "@/components/auth/reset-password-form";
 
 export default function ResetPasswordPage() {
   return (
-    <div className="flex min-h-dvh items-center justify-center bg-gray-50 px-4">
+    <div className="flex min-h-dvh items-center justify-center bg-background px-4">
       <div className="w-full max-w-sm">
         <div className="mb-8 text-center">
-          <h1 className="text-2xl font-bold text-gray-900">新しいパスワードを設定</h1>
-          <p className="mt-2 text-sm text-gray-600">
+          <h1 className="text-2xl font-bold tracking-tight text-foreground">新しいパスワードを設定</h1>
+          <p className="mt-2 text-sm text-muted">
             新しいパスワードを入力してください
           </p>
         </div>

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -28,23 +28,23 @@ export default function SettingsPage() {
   };
 
   return (
-    <div className="min-h-dvh bg-gray-50">
-      <header className="sticky top-0 z-30 flex items-center gap-3 bg-white/95 border-b border-gray-100 px-4 py-3">
-        <button onClick={() => router.back()} className="text-gray-600">
+    <div className="min-h-dvh bg-background">
+      <header className="sticky top-0 z-30 flex items-center gap-3 bg-surface/95 backdrop-blur border-b border-border px-4 py-3">
+        <button onClick={() => router.back()} className="text-muted hover:text-foreground">
           <ArrowLeft size={24} />
         </button>
-        <h1 className="text-lg font-bold text-gray-900">設定</h1>
+        <h1 className="text-lg font-bold tracking-tight text-foreground">設定</h1>
       </header>
 
       <div className="mx-auto max-w-lg p-4 flex flex-col gap-6">
         {profile && (
-          <div className="rounded-xl bg-white p-4 shadow-sm border border-gray-100">
+          <div className="rounded-xl bg-surface p-4 border border-border">
             <ProfileEditor profile={profile} onUpdate={setProfile} />
           </div>
         )}
 
         {household && profile && (
-          <div className="rounded-xl bg-white p-4 shadow-sm border border-gray-100">
+          <div className="rounded-xl bg-surface p-4 border border-border">
             <HouseholdSettings
               household={household}
               onUpdate={setHousehold}
@@ -54,11 +54,11 @@ export default function SettingsPage() {
           </div>
         )}
 
-        <div className="rounded-xl bg-white p-4 shadow-sm border border-gray-100">
+        <div className="rounded-xl bg-surface p-4 border border-border">
           <NotificationSettings />
         </div>
 
-        <div className="rounded-xl bg-white p-4 shadow-sm border border-gray-100">
+        <div className="rounded-xl bg-surface p-4 border border-border">
           <CategorySettings
             categories={categories}
             onAdd={async (name, color) => { await addCategory(name, color); }}
@@ -70,7 +70,7 @@ export default function SettingsPage() {
 
         <button
           onClick={handleLogout}
-          className="flex items-center justify-center gap-2 rounded-xl bg-white p-4 text-red-600 font-medium shadow-sm border border-gray-100 hover:bg-red-50"
+          className="flex items-center justify-center gap-2 rounded-xl bg-surface p-4 text-danger font-medium border border-border hover:bg-surface-strong"
         >
           <LogOut size={18} />
           ログアウト

--- a/src/app/signup/page.tsx
+++ b/src/app/signup/page.tsx
@@ -3,18 +3,18 @@ import { SignupForm } from "@/components/auth/signup-form";
 
 export default function SignupPage() {
   return (
-    <div className="flex min-h-dvh items-center justify-center bg-gray-50 px-4">
+    <div className="flex min-h-dvh items-center justify-center bg-background px-4">
       <div className="w-full max-w-sm">
         <div className="mb-8 text-center">
-          <h1 className="text-2xl font-bold text-gray-900">新規登録</h1>
-          <p className="mt-2 text-sm text-gray-600">
+          <h1 className="text-2xl font-bold tracking-tight text-foreground">新規登録</h1>
+          <p className="mt-2 text-sm text-muted">
             アカウントを作成して始めましょう
           </p>
         </div>
         <SignupForm />
-        <p className="mt-6 text-center text-sm text-gray-600">
+        <p className="mt-6 text-center text-sm text-muted">
           すでにアカウントをお持ちの方は{" "}
-          <Link href="/login" className="font-medium text-indigo-600 hover:text-indigo-500">
+          <Link href="/login" className="font-medium text-primary hover:text-primary-dark">
             ログイン
           </Link>
         </p>

--- a/src/components/auth/forgot-password-form.tsx
+++ b/src/components/auth/forgot-password-form.tsx
@@ -24,12 +24,12 @@ export function ForgotPasswordForm() {
 
   if (sent) {
     return (
-      <div className="rounded-lg bg-green-50 p-4 text-sm text-green-700">
+      <div className="rounded border border-border bg-success/10 p-4 text-sm text-success">
         メールを送信しました。メールボックスをご確認ください。
         {process.env.NODE_ENV === "development" && (
           <>
             <br />
-            <span className="text-xs text-green-600">
+            <span className="text-xs text-muted">
               （ローカル開発時は localhost:54324 の Inbucket で確認できます）
             </span>
           </>
@@ -41,7 +41,7 @@ export function ForgotPasswordForm() {
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
       <div className="flex flex-col gap-1.5">
-        <label htmlFor="email" className="text-sm font-medium text-gray-700">
+        <label htmlFor="email" className="text-sm font-medium text-foreground">
           メールアドレス
         </label>
         <input
@@ -50,14 +50,14 @@ export function ForgotPasswordForm() {
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           required
-          className="rounded-lg border border-gray-300 px-4 py-3 text-base outline-none transition-colors focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20"
+          className="rounded border border-border-strong bg-surface px-4 py-3 text-base text-foreground placeholder:text-subtle outline-none transition-colors focus:border-focus focus:ring-2 focus:ring-focus/15"
           placeholder="mail@example.com"
         />
       </div>
       <button
         type="submit"
         disabled={loading}
-        className="mt-2 rounded-lg bg-indigo-600 px-4 py-3 text-base font-semibold text-white transition-colors hover:bg-indigo-700 disabled:opacity-50"
+        className="mt-2 rounded bg-primary px-4 py-3 text-base font-semibold text-white transition-colors hover:bg-primary-dark disabled:opacity-50"
       >
         {loading ? "送信中..." : "リセットメールを送信"}
       </button>

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -36,12 +36,12 @@ export function LoginForm() {
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
       {error && (
-        <div className="rounded-lg bg-red-50 p-3 text-sm text-red-600">
+        <div className="rounded border border-border bg-danger/10 p-3 text-sm text-danger">
           {error}
         </div>
       )}
       <div className="flex flex-col gap-1.5">
-        <label htmlFor="email" className="text-sm font-medium text-gray-700">
+        <label htmlFor="email" className="text-sm font-medium text-foreground">
           メールアドレス
         </label>
         <input
@@ -50,14 +50,14 @@ export function LoginForm() {
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           required
-          className="rounded-lg border border-gray-300 px-4 py-3 text-base outline-none transition-colors focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20"
+          className="rounded border border-border-strong bg-surface px-4 py-3 text-base text-foreground placeholder:text-subtle outline-none transition-colors focus:border-focus focus:ring-2 focus:ring-focus/15"
           placeholder="mail@example.com"
         />
       </div>
       <div className="flex flex-col gap-1.5">
         <label
           htmlFor="password"
-          className="text-sm font-medium text-gray-700"
+          className="text-sm font-medium text-foreground"
         >
           パスワード
         </label>
@@ -68,11 +68,11 @@ export function LoginForm() {
           onChange={(e) => setPassword(e.target.value)}
           required
           minLength={8}
-          className="rounded-lg border border-gray-300 px-4 py-3 text-base outline-none transition-colors focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20"
+          className="rounded border border-border-strong bg-surface px-4 py-3 text-base text-foreground placeholder:text-subtle outline-none transition-colors focus:border-focus focus:ring-2 focus:ring-focus/15"
           placeholder="8文字以上"
         />
         <div className="flex justify-end">
-          <Link href="/forgot-password" className="text-xs text-indigo-600 hover:text-indigo-500">
+          <Link href="/forgot-password" className="text-xs text-primary hover:text-primary-dark">
             パスワードをお忘れですか？
           </Link>
         </div>
@@ -80,7 +80,7 @@ export function LoginForm() {
       <button
         type="submit"
         disabled={loading}
-        className="mt-2 rounded-lg bg-indigo-600 px-4 py-3 text-base font-semibold text-white transition-colors hover:bg-indigo-700 disabled:opacity-50"
+        className="mt-2 rounded bg-primary px-4 py-3 text-base font-semibold text-white transition-colors hover:bg-primary-dark disabled:opacity-50"
       >
         {loading ? "ログイン中..." : "ログイン"}
       </button>

--- a/src/components/auth/reset-password-form.tsx
+++ b/src/components/auth/reset-password-form.tsx
@@ -42,12 +42,12 @@ export function ResetPasswordForm() {
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
       {error && (
-        <div className="rounded-lg bg-red-50 p-3 text-sm text-red-600">
+        <div className="rounded border border-border bg-danger/10 p-3 text-sm text-danger">
           {error}
         </div>
       )}
       <div className="flex flex-col gap-1.5">
-        <label htmlFor="password" className="text-sm font-medium text-gray-700">
+        <label htmlFor="password" className="text-sm font-medium text-foreground">
           新しいパスワード
         </label>
         <input
@@ -57,12 +57,12 @@ export function ResetPasswordForm() {
           onChange={(e) => setPassword(e.target.value)}
           required
           minLength={8}
-          className="rounded-lg border border-gray-300 px-4 py-3 text-base outline-none transition-colors focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20"
+          className="rounded border border-border-strong bg-surface px-4 py-3 text-base text-foreground placeholder:text-subtle outline-none transition-colors focus:border-focus focus:ring-2 focus:ring-focus/15"
           placeholder="8文字以上"
         />
       </div>
       <div className="flex flex-col gap-1.5">
-        <label htmlFor="confirm" className="text-sm font-medium text-gray-700">
+        <label htmlFor="confirm" className="text-sm font-medium text-foreground">
           パスワード（確認）
         </label>
         <input
@@ -72,14 +72,14 @@ export function ResetPasswordForm() {
           onChange={(e) => setConfirm(e.target.value)}
           required
           minLength={8}
-          className="rounded-lg border border-gray-300 px-4 py-3 text-base outline-none transition-colors focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20"
+          className="rounded border border-border-strong bg-surface px-4 py-3 text-base text-foreground placeholder:text-subtle outline-none transition-colors focus:border-focus focus:ring-2 focus:ring-focus/15"
           placeholder="8文字以上"
         />
       </div>
       <button
         type="submit"
         disabled={loading}
-        className="mt-2 rounded-lg bg-indigo-600 px-4 py-3 text-base font-semibold text-white transition-colors hover:bg-indigo-700 disabled:opacity-50"
+        className="mt-2 rounded bg-primary px-4 py-3 text-base font-semibold text-white transition-colors hover:bg-primary-dark disabled:opacity-50"
       >
         {loading ? "更新中..." : "パスワードを更新"}
       </button>

--- a/src/components/auth/signup-form.tsx
+++ b/src/components/auth/signup-form.tsx
@@ -58,24 +58,24 @@ export function SignupForm() {
   if (step === "check-email") {
     return (
       <div className="flex flex-col items-center gap-5 text-center">
-        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-indigo-100">
-          <Mail className="h-8 w-8 text-indigo-600" />
+        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-primary-soft">
+          <Mail className="h-8 w-8 text-primary" />
         </div>
         <div className="flex flex-col gap-2">
-          <p className="text-base font-semibold text-gray-900">確認メールを送信しました</p>
-          <p className="text-sm text-gray-600">
-            <span className="font-medium text-gray-800">{email}</span> に確認メールを送りました。
+          <p className="text-base font-semibold text-foreground">確認メールを送信しました</p>
+          <p className="text-sm text-muted">
+            <span className="font-medium text-foreground">{email}</span> に確認メールを送りました。
           </p>
-          <p className="text-sm text-gray-600">
+          <p className="text-sm text-muted">
             メール内のリンクをクリックすると登録が完了します。
           </p>
         </div>
-        <div className="w-full rounded-lg bg-amber-50 p-3 text-left text-sm text-amber-700">
+        <div className="w-full rounded border border-border bg-warning/10 p-3 text-left text-sm text-warning">
           メールが届かない場合は、迷惑メールフォルダもご確認ください。
         </div>
         <Link
           href="/login"
-          className="text-sm font-medium text-indigo-600 hover:text-indigo-500"
+          className="text-sm font-medium text-primary hover:text-primary-dark"
         >
           ログイン画面へ戻る
         </Link>
@@ -86,14 +86,14 @@ export function SignupForm() {
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
       {error && (
-        <div className="rounded-lg bg-red-50 p-3 text-sm text-red-600">
+        <div className="rounded border border-border bg-danger/10 p-3 text-sm text-danger">
           {error}
         </div>
       )}
       <div className="flex flex-col gap-1.5">
         <label
           htmlFor="nickname"
-          className="text-sm font-medium text-gray-700"
+          className="text-sm font-medium text-foreground"
         >
           ニックネーム
         </label>
@@ -103,12 +103,12 @@ export function SignupForm() {
           value={nickname}
           onChange={(e) => setNickname(e.target.value)}
           required
-          className="rounded-lg border border-gray-300 px-4 py-3 text-base outline-none transition-colors focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20"
+          className="rounded border border-border-strong bg-surface px-4 py-3 text-base text-foreground placeholder:text-subtle outline-none transition-colors focus:border-focus focus:ring-2 focus:ring-focus/15"
           placeholder="ニックネーム"
         />
       </div>
       <div className="flex flex-col gap-1.5">
-        <label htmlFor="email" className="text-sm font-medium text-gray-700">
+        <label htmlFor="email" className="text-sm font-medium text-foreground">
           メールアドレス
         </label>
         <input
@@ -117,14 +117,14 @@ export function SignupForm() {
           value={email}
           onChange={(e) => setEmail(e.target.value)}
           required
-          className="rounded-lg border border-gray-300 px-4 py-3 text-base outline-none transition-colors focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20"
+          className="rounded border border-border-strong bg-surface px-4 py-3 text-base text-foreground placeholder:text-subtle outline-none transition-colors focus:border-focus focus:ring-2 focus:ring-focus/15"
           placeholder="mail@example.com"
         />
       </div>
       <div className="flex flex-col gap-1.5">
         <label
           htmlFor="password"
-          className="text-sm font-medium text-gray-700"
+          className="text-sm font-medium text-foreground"
         >
           パスワード
         </label>
@@ -135,14 +135,14 @@ export function SignupForm() {
           onChange={(e) => setPassword(e.target.value)}
           required
           minLength={8}
-          className="rounded-lg border border-gray-300 px-4 py-3 text-base outline-none transition-colors focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20"
+          className="rounded border border-border-strong bg-surface px-4 py-3 text-base text-foreground placeholder:text-subtle outline-none transition-colors focus:border-focus focus:ring-2 focus:ring-focus/15"
           placeholder="8文字以上"
         />
       </div>
       <button
         type="submit"
         disabled={loading}
-        className="mt-2 rounded-lg bg-indigo-600 px-4 py-3 text-base font-semibold text-white transition-colors hover:bg-indigo-700 disabled:opacity-50"
+        className="mt-2 rounded bg-primary px-4 py-3 text-base font-semibold text-white transition-colors hover:bg-primary-dark disabled:opacity-50"
       >
         {loading ? "登録中..." : "アカウント作成"}
       </button>

--- a/src/components/category/category-manager.tsx
+++ b/src/components/category/category-manager.tsx
@@ -85,7 +85,7 @@ function SortableCategoryRow({
             value={name}
             onChange={(e) => onNameChange(e.target.value)}
             maxLength={50}
-            className="rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:border-indigo-500"
+            className="rounded border border-border-strong bg-surface px-3 py-2 text-sm text-foreground outline-none focus:border-focus focus:ring-2 focus:ring-focus/15"
             autoFocus
           />
           <div className="flex gap-1.5">
@@ -93,7 +93,7 @@ function SortableCategoryRow({
               <button
                 key={c}
                 onClick={() => onColorChange(c)}
-                className={`h-6 w-6 rounded-full border-2 ${color === c ? "border-gray-800" : "border-transparent"}`}
+                className={`h-6 w-6 rounded-full border-2 ${color === c ? "border-foreground" : "border-transparent"}`}
                 style={{ backgroundColor: c }}
               />
             ))}
@@ -108,7 +108,7 @@ function SortableCategoryRow({
           <button
             {...attributes}
             {...listeners}
-            className="touch-none cursor-grab p-1 text-gray-300 hover:text-gray-500 active:cursor-grabbing shrink-0"
+            className="touch-none cursor-grab p-1 text-subtle hover:text-muted active:cursor-grabbing shrink-0"
             tabIndex={-1}
           >
             <GripVertical size={16} />
@@ -117,11 +117,11 @@ function SortableCategoryRow({
             className="h-4 w-4 rounded-full shrink-0"
             style={{ backgroundColor: cat.color }}
           />
-          <span className="flex-1 text-sm text-gray-900">{cat.name}</span>
-          <button onClick={() => onStartEdit(cat)} className="p-1 text-gray-400 hover:text-gray-600">
+          <span className="flex-1 text-sm text-foreground">{cat.name}</span>
+          <button onClick={() => onStartEdit(cat)} className="p-1 text-subtle hover:text-foreground">
             <Pencil size={16} />
           </button>
-          <button onClick={() => onDelete(cat.id)} className="p-1 text-gray-400 hover:text-red-600">
+          <button onClick={() => onDelete(cat.id)} className="p-1 text-subtle hover:text-danger">
             <Trash2 size={16} />
           </button>
         </>
@@ -132,10 +132,10 @@ function SortableCategoryRow({
 
 function CategoryRowOverlay({ cat }: { cat: Category }) {
   return (
-    <div className="flex items-center gap-2 rounded-lg bg-white px-2 py-1 shadow-lg opacity-90 border border-gray-100">
-      <GripVertical size={16} className="text-gray-400 shrink-0" />
+    <div className="flex items-center gap-2 rounded-lg bg-surface px-2 py-1 shadow-md opacity-90 border border-border">
+      <GripVertical size={16} className="text-subtle shrink-0" />
       <div className="h-4 w-4 rounded-full shrink-0" style={{ backgroundColor: cat.color }} />
-      <span className="flex-1 text-sm text-gray-900">{cat.name}</span>
+      <span className="flex-1 text-sm text-foreground">{cat.name}</span>
     </div>
   );
 }
@@ -221,13 +221,13 @@ export function CategoryManager({ categories, onAdd, onUpdate, onDelete, onReord
       </DndContext>
 
       {isAdding ? (
-        <div className="flex flex-col gap-2 rounded-lg border border-dashed border-gray-300 p-3">
+        <div className="flex flex-col gap-2 rounded-lg border border-dashed border-border-strong p-3">
           <input
             value={name}
             onChange={(e) => setName(e.target.value)}
             placeholder="カテゴリ名"
             maxLength={50}
-            className="rounded-lg border border-gray-300 px-3 py-2 text-sm outline-none focus:border-indigo-500"
+            className="rounded border border-border-strong bg-surface px-3 py-2 text-sm text-foreground outline-none focus:border-focus focus:ring-2 focus:ring-focus/15"
             autoFocus
           />
           <div className="flex gap-1.5">
@@ -235,7 +235,7 @@ export function CategoryManager({ categories, onAdd, onUpdate, onDelete, onReord
               <button
                 key={c}
                 onClick={() => setColor(c)}
-                className={`h-6 w-6 rounded-full border-2 ${color === c ? "border-gray-800" : "border-transparent"}`}
+                className={`h-6 w-6 rounded-full border-2 ${color === c ? "border-foreground" : "border-transparent"}`}
                 style={{ backgroundColor: c }}
               />
             ))}
@@ -248,7 +248,7 @@ export function CategoryManager({ categories, onAdd, onUpdate, onDelete, onReord
       ) : (
         <button
           onClick={() => { setIsAdding(true); setEditingId(null); }}
-          className="flex items-center gap-2 rounded-lg border border-dashed border-gray-300 p-3 text-sm text-gray-500 hover:border-gray-400 hover:text-gray-700"
+          className="flex items-center gap-2 rounded-lg border border-dashed border-border-strong p-3 text-sm text-muted hover:border-foreground hover:text-foreground"
         >
           <Plus size={16} />
           カテゴリを追加

--- a/src/components/category/category-tabs.tsx
+++ b/src/components/category/category-tabs.tsx
@@ -130,10 +130,10 @@ export function CategoryTabs({
     onSelect(id);
   };
 
-  // Get background color for active tab
+  // Get background color for active tab — Notion-style soft tinted pill
   const getActiveBg = (index: number): string => {
     const cat = categories[index];
-    return cat ? `${cat.color}20` : "#e0e7ff";
+    return cat ? `${cat.color}1a` : "#ebeae8";
   };
 
   if (loading && categories.length === 0) {
@@ -142,7 +142,7 @@ export function CategoryTabs({
         {[56, 64, 52].map((w, i) => (
           <div
             key={i}
-            className="h-8 rounded-full bg-gray-200 animate-pulse"
+            className="h-8 rounded-full bg-surface-strong animate-pulse"
             style={{ width: `${w}px` }}
           />
         ))}
@@ -171,7 +171,7 @@ export function CategoryTabs({
             onClick={() => handleSelect(cat.id, i)}
             className="relative z-10 flex-1 flex items-center justify-center rounded-full py-1.5 text-sm font-medium transition-colors"
           >
-            <span style={{ color: selectedId === cat.id ? cat.color : "#6b7280" }}>
+            <span style={{ color: selectedId === cat.id ? cat.color : "var(--text-muted)" }}>
               {cat.name}
             </span>
           </button>

--- a/src/components/household/create-form.tsx
+++ b/src/components/household/create-form.tsx
@@ -68,12 +68,12 @@ export function CreateHouseholdForm() {
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
       {error && (
-        <div className="rounded-lg bg-red-50 p-3 text-sm text-red-600">
+        <div className="rounded border border-border bg-danger/10 p-3 text-sm text-danger">
           {error}
         </div>
       )}
       <div className="flex flex-col gap-1.5">
-        <label htmlFor="name" className="text-sm font-medium text-gray-700">
+        <label htmlFor="name" className="text-sm font-medium text-foreground">
           家族の名前
         </label>
         <input
@@ -82,14 +82,14 @@ export function CreateHouseholdForm() {
           value={name}
           onChange={(e) => setName(e.target.value)}
           maxLength={50}
-          className="rounded-lg border border-gray-300 px-4 py-3 text-base outline-none transition-colors focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20"
+          className="rounded border border-border-strong bg-surface px-4 py-3 text-base text-foreground placeholder:text-subtle outline-none transition-colors focus:border-focus focus:ring-2 focus:ring-focus/15"
           placeholder="わが家"
         />
       </div>
       <button
         type="submit"
         disabled={loading}
-        className="mt-2 rounded-lg bg-indigo-600 px-4 py-3 text-base font-semibold text-white transition-colors hover:bg-indigo-700 disabled:opacity-50"
+        className="mt-2 rounded bg-primary px-4 py-3 text-base font-semibold text-white transition-colors hover:bg-primary-dark disabled:opacity-50"
       >
         {loading ? "作成中..." : "ハウスホールドを作成"}
       </button>

--- a/src/components/household/join-form.tsx
+++ b/src/components/household/join-form.tsx
@@ -34,12 +34,12 @@ export function JoinHouseholdForm() {
   return (
     <form onSubmit={handleSubmit} className="flex flex-col gap-4">
       {error && (
-        <div className="rounded-lg bg-red-50 p-3 text-sm text-red-600">
+        <div className="rounded border border-border bg-danger/10 p-3 text-sm text-danger">
           {error}
         </div>
       )}
       <div className="flex flex-col gap-1.5">
-        <label htmlFor="code" className="text-sm font-medium text-gray-700">
+        <label htmlFor="code" className="text-sm font-medium text-foreground">
           招待コード
         </label>
         <input
@@ -49,14 +49,14 @@ export function JoinHouseholdForm() {
           onChange={(e) => setCode(e.target.value)}
           required
           maxLength={16}
-          className="rounded-lg border border-gray-300 px-4 py-3 text-center text-2xl font-mono tracking-widest uppercase outline-none transition-colors focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20"
+          className="rounded border border-border-strong bg-surface px-4 py-3 text-center text-2xl font-mono tracking-widest uppercase text-foreground placeholder:text-subtle outline-none transition-colors focus:border-focus focus:ring-2 focus:ring-focus/15"
           placeholder="XXXXXXXXXXXXXXXX"
         />
       </div>
       <button
         type="submit"
         disabled={loading || code.length < 16}
-        className="mt-2 rounded-lg bg-indigo-600 px-4 py-3 text-base font-semibold text-white transition-colors hover:bg-indigo-700 disabled:opacity-50"
+        className="mt-2 rounded bg-primary px-4 py-3 text-base font-semibold text-white transition-colors hover:bg-primary-dark disabled:opacity-50"
       >
         {loading ? "参加中..." : "ハウスホールドに参加"}
       </button>

--- a/src/components/recommendation/recommendation-card.tsx
+++ b/src/components/recommendation/recommendation-card.tsx
@@ -33,17 +33,17 @@ export function RecommendationCard({
       animate={{ opacity: 1, y: 0 }}
       exit={{ opacity: 0, x: 80 }}
       transition={{ duration: 0.2 }}
-      className="bg-white rounded-lg shadow-sm border border-indigo-100 p-3 flex flex-col gap-2"
+      className="bg-surface rounded-lg border border-border p-3 flex flex-col gap-2"
       style={{
         borderLeftWidth: categoryColor ? 3 : undefined,
         borderLeftColor: categoryColor ?? undefined,
       }}
     >
       <div>
-        <p className="text-sm font-medium text-gray-900">
+        <p className="text-sm font-medium text-foreground">
           {recommendation.latest_title}
         </p>
-        <p className="text-xs text-gray-500 mt-0.5">
+        <p className="text-xs text-muted mt-0.5">
           前回から{recommendation.days_since_last}日経過 ・ 約
           {formatInterval(recommendation.median_interval_days)}ごと
         </p>

--- a/src/components/recommendation/recommendation-section.tsx
+++ b/src/components/recommendation/recommendation-section.tsx
@@ -25,10 +25,10 @@ export function RecommendationSection({
   );
 
   return (
-    <div className="bg-indigo-50/50 rounded-xl p-3 mx-4 mb-3">
+    <div className="bg-primary-soft rounded-xl p-3 mx-4 mb-3 border border-border">
       <div className="flex items-center gap-1.5 mb-2">
-        <Lightbulb className="w-4 h-4 text-indigo-600" />
-        <span className="text-xs font-semibold text-indigo-600">
+        <Lightbulb className="w-4 h-4 text-primary" />
+        <span className="text-xs font-semibold text-primary">
           そろそろやる時期かも
         </span>
       </div>

--- a/src/components/settings/avatar-picker.tsx
+++ b/src/components/settings/avatar-picker.tsx
@@ -15,13 +15,13 @@ export function AvatarPicker({ isOpen, onClose, selectedKey, onSelect }: AvatarP
     <BottomSheet isOpen={isOpen} onClose={onClose}>
       <div className="flex flex-col gap-4 pb-4">
         <div className="flex items-center justify-between">
-          <h3 className="text-sm font-semibold text-gray-900">アイコンを選ぶ</h3>
+          <h3 className="text-sm font-semibold text-foreground">アイコンを選ぶ</h3>
           <button
             onClick={() => {
               onSelect(null);
               onClose();
             }}
-            className="text-xs text-gray-500 hover:text-gray-700 px-2 py-1 rounded bg-gray-100"
+            className="text-xs text-muted hover:text-foreground px-2 py-1 rounded bg-surface-strong"
           >
             リセット
           </button>
@@ -34,15 +34,15 @@ export function AvatarPicker({ isOpen, onClose, selectedKey, onSelect }: AvatarP
                 onSelect(preset.key);
                 onClose();
               }}
-              className={`flex flex-col items-center gap-1 rounded-xl p-2 transition-colors ${
+              className={`flex flex-col items-center gap-1 rounded-lg p-2 transition-colors ${
                 selectedKey === preset.key
-                  ? "bg-indigo-50 ring-2 ring-indigo-500"
-                  : "hover:bg-gray-50"
+                  ? "bg-primary-soft ring-2 ring-focus"
+                  : "hover:bg-surface-strong"
               }`}
               title={preset.label}
             >
               <span className="text-2xl">{preset.emoji}</span>
-              <span className="text-[10px] text-gray-500 leading-tight">{preset.label}</span>
+              <span className="text-[10px] text-muted leading-tight">{preset.label}</span>
             </button>
           ))}
         </div>

--- a/src/components/settings/category-settings.tsx
+++ b/src/components/settings/category-settings.tsx
@@ -14,7 +14,7 @@ interface CategorySettingsProps {
 export function CategorySettings({ categories, onAdd, onUpdate, onDelete, onReorder }: CategorySettingsProps) {
   return (
     <div className="flex flex-col gap-3">
-      <h3 className="text-sm font-semibold text-gray-900">カテゴリ管理</h3>
+      <h3 className="text-sm font-semibold text-foreground">カテゴリ管理</h3>
       <CategoryManager
         categories={categories}
         onAdd={onAdd}

--- a/src/components/settings/household-settings.tsx
+++ b/src/components/settings/household-settings.tsx
@@ -59,10 +59,10 @@ export function HouseholdSettings({
 
   return (
     <div className="flex flex-col gap-4">
-      <h3 className="text-sm font-semibold text-gray-900">家族グループ</h3>
+      <h3 className="text-sm font-semibold text-foreground">家族グループ</h3>
 
       <div className="flex flex-col gap-1.5">
-        <label htmlFor="household-name" className="text-xs text-gray-500">
+        <label htmlFor="household-name" className="text-xs text-muted">
           家族の名前
         </label>
         <div className="flex gap-2">
@@ -71,7 +71,7 @@ export function HouseholdSettings({
             value={name}
             onChange={(e) => setName(e.target.value)}
             maxLength={50}
-            className="flex-1 rounded-lg border border-gray-300 px-4 py-2.5 text-sm outline-none focus:border-indigo-500"
+            className="flex-1 rounded border border-border-strong bg-surface px-4 py-2.5 text-sm text-foreground outline-none focus:border-focus focus:ring-2 focus:ring-focus/15"
           />
           <Button size="sm" onClick={handleSave} disabled={saving}>
             {saving ? "..." : "保存"}
@@ -80,43 +80,43 @@ export function HouseholdSettings({
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <label className="text-xs text-gray-500">招待コード</label>
+        <label className="text-xs text-muted">招待コード</label>
         <div className="flex items-center gap-2">
-          <div className="flex-1 rounded-lg bg-gray-50 px-4 py-2.5 font-mono text-lg tracking-widest text-center">
+          <div className="flex-1 rounded border border-border bg-background px-4 py-2.5 font-mono text-lg tracking-widest text-center text-foreground">
             {inviteCode || "---"}
           </div>
           <button
             onClick={copyCode}
-            className="rounded-lg bg-gray-100 p-2.5 text-gray-600 hover:bg-gray-200"
+            className="rounded bg-surface-strong p-2.5 text-muted hover:bg-border-strong"
             title="コピー"
           >
             <Copy size={18} />
           </button>
           <button
             onClick={regenerateCode}
-            className="rounded-lg bg-gray-100 p-2.5 text-gray-600 hover:bg-gray-200"
+            className="rounded bg-surface-strong p-2.5 text-muted hover:bg-border-strong"
             title="再発行"
           >
             <RefreshCw size={18} />
           </button>
         </div>
         {copied && (
-          <p className="text-xs text-green-600">コピーしました</p>
+          <p className="text-xs text-success">コピーしました</p>
         )}
-        <p className="text-xs text-gray-400">
+        <p className="text-xs text-subtle">
           招待コードは24時間有効です
         </p>
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <label className="text-xs text-gray-500">メンバー</label>
+        <label className="text-xs text-muted">メンバー</label>
         <div className="flex flex-col gap-2">
           {members.map((member) => (
             <div key={member.id} className="flex items-center gap-3 py-2">
               <Avatar profile={member} size="md" />
-              <span className="flex-1 text-sm text-gray-900">{member.nickname}</span>
+              <span className="flex-1 text-sm text-foreground">{member.nickname}</span>
               {member.id === currentUserId && (
-                <span className="text-xs text-gray-500 bg-gray-100 px-2 py-1 rounded">
+                <span className="text-xs text-muted bg-surface-strong px-2 py-1 rounded">
                   あなた
                 </span>
               )}
@@ -124,7 +124,7 @@ export function HouseholdSettings({
           ))}
         </div>
         {members.length === 0 && (
-          <p className="text-sm text-gray-400">メンバーがいません</p>
+          <p className="text-sm text-subtle">メンバーがいません</p>
         )}
       </div>
     </div>

--- a/src/components/settings/notification-settings.tsx
+++ b/src/components/settings/notification-settings.tsx
@@ -45,19 +45,19 @@ export function NotificationSettings() {
 
   return (
     <div>
-      <h2 className="text-sm font-semibold text-gray-500 mb-3">プッシュ通知</h2>
+      <h2 className="text-sm font-semibold text-foreground mb-3">プッシュ通知</h2>
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-3">
           {isSubscribed ? (
             <Bell size={20} className="text-primary" />
           ) : (
-            <BellOff size={20} className="text-gray-400" />
+            <BellOff size={20} className="text-subtle" />
           )}
           <div>
-            <p className="text-sm font-medium text-gray-900">
+            <p className="text-sm font-medium text-foreground">
               {isSubscribed ? "通知ON" : "通知OFF"}
             </p>
-            <p className="text-xs text-gray-500">
+            <p className="text-xs text-muted">
               {permission === "denied"
                 ? "ブラウザの設定で通知がブロックされています"
                 : "タスクの追加・完了時に通知を受け取ります"}
@@ -68,7 +68,7 @@ export function NotificationSettings() {
           onClick={handleToggle}
           disabled={isDisabled}
           className={`relative inline-flex h-6 w-11 items-center rounded-full transition-colors ${
-            isSubscribed ? "bg-primary" : "bg-gray-300"
+            isSubscribed ? "bg-primary" : "bg-border-strong"
           } ${isDisabled ? "opacity-50 cursor-not-allowed" : ""}`}
         >
           <span

--- a/src/components/settings/profile-editor.tsx
+++ b/src/components/settings/profile-editor.tsx
@@ -47,7 +47,7 @@ export function ProfileEditor({ profile, onUpdate }: ProfileEditorProps) {
 
   return (
     <div className="flex flex-col gap-3">
-      <h3 className="text-sm font-semibold text-gray-900">プロフィール</h3>
+      <h3 className="text-sm font-semibold text-foreground">プロフィール</h3>
 
       <div className="flex justify-center">
         <button
@@ -58,14 +58,14 @@ export function ProfileEditor({ profile, onUpdate }: ProfileEditorProps) {
             profile={{ nickname, avatar_url: previewAvatarUrl }}
             size="lg"
           />
-          <div className="absolute bottom-0 right-0 flex h-6 w-6 items-center justify-center rounded-full bg-indigo-600 text-white shadow-sm group-hover:bg-indigo-700 transition-colors">
+          <div className="absolute bottom-0 right-0 flex h-6 w-6 items-center justify-center rounded-full bg-primary text-white group-hover:bg-primary-dark transition-colors">
             <Pencil size={12} />
           </div>
         </button>
       </div>
 
       <div className="flex flex-col gap-1.5">
-        <label htmlFor="nickname" className="text-xs text-gray-500">
+        <label htmlFor="nickname" className="text-xs text-muted">
           ニックネーム
         </label>
         <input
@@ -73,7 +73,7 @@ export function ProfileEditor({ profile, onUpdate }: ProfileEditorProps) {
           value={nickname}
           onChange={(e) => setNickname(e.target.value)}
           maxLength={30}
-          className="rounded-lg border border-gray-300 px-4 py-2.5 text-sm outline-none focus:border-indigo-500"
+          className="rounded border border-border-strong bg-surface px-4 py-2.5 text-sm text-foreground outline-none focus:border-focus focus:ring-2 focus:ring-focus/15"
         />
       </div>
       <Button size="sm" onClick={handleSave} disabled={saving}>

--- a/src/components/task/category-picker.tsx
+++ b/src/components/task/category-picker.tsx
@@ -20,7 +20,7 @@ export function CategoryPicker({
   return (
     <div>
       {label && (
-        <label className="text-xs font-medium text-gray-500 mb-1.5 block">{label}</label>
+        <label className="text-xs font-medium text-muted mb-1.5 block">{label}</label>
       )}
       <div className="flex flex-wrap gap-1.5">
         {showNone && (
@@ -28,7 +28,7 @@ export function CategoryPicker({
             type="button"
             onClick={() => onChange(null)}
             className={`rounded-full px-3 py-1 text-xs font-medium ${
-              selectedId === null ? "bg-gray-800 text-white" : "bg-gray-100 text-gray-600"
+              selectedId === null ? "bg-foreground text-white" : "bg-surface-strong text-muted"
             }`}
           >
             なし
@@ -40,7 +40,7 @@ export function CategoryPicker({
             type="button"
             onClick={() => onChange(cat.id)}
             className={`rounded-full px-3 py-1 text-xs font-medium transition-colors ${
-              selectedId === cat.id ? "text-white" : "bg-gray-100 text-gray-600"
+              selectedId === cat.id ? "text-white" : "bg-surface-strong text-muted"
             }`}
             style={selectedId === cat.id ? { backgroundColor: cat.color } : undefined}
           >

--- a/src/components/task/quick-date-picker.tsx
+++ b/src/components/task/quick-date-picker.tsx
@@ -23,7 +23,7 @@ export function QuickDatePicker({
   return (
     <div>
       {label && (
-        <label className="text-xs font-medium text-gray-500 mb-1.5 block">{label}</label>
+        <label className="text-xs font-medium text-muted mb-1.5 block">{label}</label>
       )}
       <div className="flex gap-2">
         <button
@@ -32,8 +32,8 @@ export function QuickDatePicker({
           aria-pressed={isTodaySelected}
           className={`rounded-full px-3 py-1 text-xs font-medium ${
             isTodaySelected
-              ? "bg-indigo-600 text-white"
-              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+              ? "bg-primary text-white"
+              : "bg-surface-strong text-muted hover:bg-border-strong"
           }`}
         >
           今日
@@ -44,8 +44,8 @@ export function QuickDatePicker({
           aria-pressed={isTomorrowSelected}
           className={`rounded-full px-3 py-1 text-xs font-medium ${
             isTomorrowSelected
-              ? "bg-indigo-600 text-white"
-              : "bg-gray-100 text-gray-600 hover:bg-gray-200"
+              ? "bg-primary text-white"
+              : "bg-surface-strong text-muted hover:bg-border-strong"
           }`}
         >
           明日
@@ -54,13 +54,13 @@ export function QuickDatePicker({
           type="date"
           value={value}
           onChange={(e) => onChange(e.target.value)}
-          className="flex-1 rounded-lg border border-gray-300 px-3 py-1 text-sm outline-none focus:border-indigo-500"
+          className="flex-1 rounded border border-border-strong bg-surface px-3 py-1 text-sm text-foreground outline-none focus:border-focus focus:ring-2 focus:ring-focus/15"
         />
         {showClear && value && (
           <button
             type="button"
             onClick={() => onChange("")}
-            className="text-xs text-gray-400 hover:text-gray-600"
+            className="text-xs text-subtle hover:text-foreground"
           >
             クリア
           </button>

--- a/src/components/task/task-create-sheet.tsx
+++ b/src/components/task/task-create-sheet.tsx
@@ -86,7 +86,7 @@ export function TaskCreateSheet({
             }}
             placeholder="タスク名を入力"
             maxLength={255}
-            className="w-full rounded-lg border border-gray-300 px-4 py-3 text-base outline-none focus:border-indigo-500"
+            className="w-full rounded border border-border-strong bg-surface px-4 py-3 text-base text-foreground placeholder:text-subtle outline-none focus:border-focus focus:ring-2 focus:ring-focus/15"
             autoFocus
             autoComplete="off"
           />
@@ -97,7 +97,7 @@ export function TaskCreateSheet({
                 <button
                   key={s}
                   type="button"
-                  className="rounded-full border border-indigo-200 bg-indigo-50 px-3 py-1.5 text-sm text-indigo-700 active:bg-indigo-100"
+                  className="rounded-full border border-border bg-primary-soft px-3 py-1.5 text-sm text-primary active:bg-primary-soft/70"
                   onClick={() => handleSelectSuggestion(s)}
                 >
                   {s}
@@ -122,7 +122,7 @@ export function TaskCreateSheet({
           placeholder="メモ（任意）"
           maxLength={5000}
           rows={2}
-          className="rounded-lg border border-gray-300 px-4 py-3 text-sm outline-none resize-none focus:border-indigo-500"
+          className="rounded border border-border-strong bg-surface px-4 py-3 text-sm text-foreground placeholder:text-subtle outline-none resize-none focus:border-focus focus:ring-2 focus:ring-focus/15"
         />
 
         <Button type="submit" disabled={!title.trim()}>

--- a/src/components/task/task-detail-modal.tsx
+++ b/src/components/task/task-detail-modal.tsx
@@ -78,7 +78,7 @@ export function TaskDetailModal({
           value={title}
           onChange={(e) => setTitle(e.target.value)}
           maxLength={255}
-          className="rounded-lg border border-gray-300 px-4 py-3 text-base font-medium outline-none focus:border-indigo-500"
+          className="rounded border border-border-strong bg-surface px-4 py-3 text-base font-medium text-foreground outline-none focus:border-focus focus:ring-2 focus:ring-focus/15"
         />
 
         {/* Category */}
@@ -99,45 +99,45 @@ export function TaskDetailModal({
 
         {/* Memo */}
         <div>
-          <label className="text-xs font-medium text-gray-500 mb-1.5 block">メモ</label>
+          <label className="text-xs font-medium text-muted mb-1.5 block">メモ</label>
           <textarea
             value={memo}
             onChange={(e) => setMemo(e.target.value)}
             placeholder="メモを入力..."
             maxLength={5000}
             rows={3}
-            className="w-full rounded-lg border border-gray-300 px-4 py-3 text-sm outline-none resize-none focus:border-indigo-500"
+            className="w-full rounded border border-border-strong bg-surface px-4 py-3 text-sm text-foreground placeholder:text-subtle outline-none resize-none focus:border-focus focus:ring-2 focus:ring-focus/15"
           />
         </div>
 
         {/* URL */}
         <div>
-          <label className="text-xs font-medium text-gray-500 mb-1.5 block">URL</label>
+          <label className="text-xs font-medium text-muted mb-1.5 block">URL</label>
           <div className="flex gap-2">
             <input
               value={url}
               onChange={(e) => { setUrl(e.target.value); setUrlError(""); }}
               placeholder="https://..."
-              className={`flex-1 rounded-lg border px-4 py-2 text-sm outline-none focus:border-indigo-500 ${urlError ? "border-red-400" : "border-gray-300"}`}
+              className={`flex-1 rounded border bg-surface px-4 py-2 text-sm text-foreground placeholder:text-subtle outline-none focus:border-focus focus:ring-2 focus:ring-focus/15 ${urlError ? "border-danger" : "border-border-strong"}`}
             />
             {url && !urlError && isValidUrl(url) && (
               <a
                 href={url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="flex items-center justify-center rounded-lg bg-gray-100 px-3 text-gray-600 hover:bg-gray-200"
+                className="flex items-center justify-center rounded bg-surface-strong px-3 text-muted hover:bg-border-strong"
               >
                 <ExternalLink size={16} />
               </a>
             )}
           </div>
           {urlError && (
-            <p className="mt-1 text-xs text-red-500">{urlError}</p>
+            <p className="mt-1 text-xs text-danger">{urlError}</p>
           )}
         </div>
 
         {/* Meta info */}
-        <div className="flex items-center gap-2 text-xs text-gray-400 border-t border-gray-100 pt-3">
+        <div className="flex items-center gap-2 text-xs text-subtle border-t border-border pt-3">
           {createdByMember && (
             <span>作成: {createdByMember.nickname || "不明"}</span>
           )}

--- a/src/components/task/task-item.tsx
+++ b/src/components/task/task-item.tsx
@@ -72,20 +72,20 @@ export const TaskItem = memo(function TaskItem({
   })();
 
   const urgencyBorderClass = isOverdue
-    ? "border-l-4 border-l-red-400"
+    ? "border border-border border-l-2 border-l-danger"
     : isToday
-    ? "border-l-4 border-l-orange-400"
+    ? "border border-border border-l-2 border-l-warning"
     : isTomorrow
-    ? "border-l-4 border-l-yellow-400"
-    : "border border-gray-100";
+    ? "border border-border border-l-2 border-l-caution"
+    : "border border-border";
 
   const dueDateClass = isOverdue
-    ? "text-red-500 font-medium"
+    ? "text-danger font-medium"
     : isToday
-    ? "text-orange-500 font-medium"
+    ? "text-warning font-medium"
     : isTomorrow
-    ? "text-yellow-600 font-medium"
-    : "text-gray-500";
+    ? "text-caution font-medium"
+    : "text-muted";
 
   const handleCardClick = () => {
     onTap(task);
@@ -120,7 +120,7 @@ export const TaskItem = memo(function TaskItem({
         {/* Delete background (shown when swiping left on done tasks) */}
         {task.is_done && !isOverlay && (
           <motion.div
-            className="absolute inset-y-0 right-0 flex items-center justify-end pr-4 rounded-lg bg-red-500"
+            className="absolute inset-y-0 right-0 flex items-center justify-end pr-4 rounded-lg bg-danger"
             style={{ width: "100%", opacity: deleteOpacity }}
           >
             <motion.div style={{ scale: deleteScale }}>
@@ -131,7 +131,7 @@ export const TaskItem = memo(function TaskItem({
 
         {/* Card */}
         <motion.div
-          className={`relative flex items-center gap-2 bg-white px-3 py-1.5 rounded-lg shadow-sm cursor-pointer transition-colors ${urgencyBorderClass}`}
+          className={`relative flex items-center gap-2 bg-surface px-3 py-1.5 rounded-lg cursor-pointer transition-colors ${urgencyBorderClass}`}
           onClick={handleCardClick}
           {...swipeProps}
         >
@@ -140,7 +140,7 @@ export const TaskItem = memo(function TaskItem({
             <div
               {...attributes}
               {...listeners}
-              className="touch-none text-gray-300 cursor-grab active:cursor-grabbing"
+              className="touch-none text-subtle cursor-grab active:cursor-grabbing"
               onClick={(e) => e.stopPropagation()}
             >
               <GripVertical size={14} />
@@ -161,8 +161,8 @@ export const TaskItem = memo(function TaskItem({
               transition={{ duration: 0.25 }}
               className={`flex h-5 w-5 items-center justify-center rounded-full border-2 transition-colors ${
                 showDone
-                  ? "border-green-500 bg-green-500"
-                  : "border-gray-300 hover:border-indigo-400"
+                  ? "border-success bg-success"
+                  : "border-border-strong hover:border-primary"
               }`}
             >
               {showDone && (
@@ -181,7 +181,7 @@ export const TaskItem = memo(function TaskItem({
           <div className="flex-1 min-w-0">
             <p
               className={`text-sm font-medium truncate ${
-                showDone ? "text-gray-400 line-through" : "text-gray-900"
+                showDone ? "text-subtle line-through" : "text-foreground"
               }`}
             >
               {task.title}
@@ -195,12 +195,12 @@ export const TaskItem = memo(function TaskItem({
                     <Calendar size={10} />
                     {formatDueDate(task.due_date)}
                     {isToday && (
-                      <span className="ml-0.5 text-orange-500 font-bold leading-none">!</span>
+                      <span className="ml-0.5 text-warning font-bold leading-none">!</span>
                     )}
                   </span>
                 )}
                 {createdBy && (
-                  <span className="text-xs text-gray-400">
+                  <span className="text-xs text-subtle">
                     {createdBy.nickname}
                   </span>
                 )}

--- a/src/components/task/task-list-skeleton.tsx
+++ b/src/components/task/task-list-skeleton.tsx
@@ -6,17 +6,17 @@ export function TaskListSkeleton() {
       {[...Array(4)].map((_, i) => (
         <div
           key={i}
-          className="flex items-center gap-3 rounded-xl bg-white p-4 shadow-sm"
+          className="flex items-center gap-3 rounded-lg bg-surface p-4 border border-border"
         >
           {/* Checkbox placeholder */}
-          <div className="h-5 w-5 shrink-0 rounded-full bg-gray-200 animate-pulse" />
+          <div className="h-5 w-5 shrink-0 rounded-full bg-surface-strong animate-pulse" />
           {/* Text lines */}
           <div className="flex-1 space-y-2">
             <div
-              className="h-4 rounded bg-gray-200 animate-pulse"
+              className="h-4 rounded bg-surface-strong animate-pulse"
               style={{ width: `${60 + i * 8}%` }}
             />
-            <div className="h-3 w-1/3 rounded bg-gray-100 animate-pulse" />
+            <div className="h-3 w-1/3 rounded bg-surface-strong animate-pulse" />
           </div>
         </div>
       ))}

--- a/src/components/task/task-list.tsx
+++ b/src/components/task/task-list.tsx
@@ -152,7 +152,7 @@ export function TaskList({
 
   if (tasks.length === 0) {
     return (
-      <div className="flex flex-col items-center justify-center py-20 text-gray-400">
+      <div className="flex flex-col items-center justify-center py-20 text-subtle">
         <p className="text-lg">タスクがありません</p>
         <p className="mt-1 text-sm">右下の＋ボタンで追加しましょう</p>
       </div>
@@ -208,13 +208,13 @@ export function TaskList({
         {doneTasks.length > 0 && (
           <>
             <div className="mt-4 flex items-center justify-between px-1">
-              <p className="text-xs font-medium text-gray-400 uppercase tracking-wider">
+              <p className="text-xs font-medium text-subtle uppercase tracking-wider">
                 完了 ({doneTasks.length})
               </p>
               <button
                 type="button"
                 onClick={() => setShowConfirm(true)}
-                className="inline-flex min-h-[40px] items-center gap-1.5 rounded-full bg-red-50 px-3 py-2 text-sm font-medium text-red-600 transition-colors hover:bg-red-100"
+                className="inline-flex min-h-[40px] items-center gap-1.5 rounded-full bg-danger/10 px-3 py-2 text-sm font-medium text-danger transition-colors hover:bg-danger/15"
               >
                 <Trash2 size={16} />
                 すべて削除

--- a/src/components/ui/avatar.tsx
+++ b/src/components/ui/avatar.tsx
@@ -24,7 +24,7 @@ export function Avatar({ profile, size = "md" }: AvatarProps) {
 
   return (
     <div
-      className={`flex items-center justify-center rounded-full bg-indigo-100 font-bold text-indigo-700 ${sizeClasses[size]}`}
+      className={`flex items-center justify-center rounded-full bg-surface-strong font-bold text-foreground ${sizeClasses[size]}`}
       title={profile.nickname}
     >
       {emoji ? (

--- a/src/components/ui/bottom-sheet.tsx
+++ b/src/components/ui/bottom-sheet.tsx
@@ -65,7 +65,7 @@ export function BottomSheet({ isOpen, onClose, title, children }: BottomSheetPro
             onClick={onClose}
           />
           <motion.div
-            className="relative w-full max-w-lg bg-white rounded-t-2xl overflow-y-auto"
+            className="relative w-full max-w-lg bg-surface rounded-t-xl border border-border overflow-y-auto"
             style={{
               maxHeight: effectiveKeyboardHeight > 0
                 ? `calc(100dvh - ${effectiveKeyboardHeight}px - 40px)`
@@ -83,10 +83,10 @@ export function BottomSheet({ isOpen, onClose, title, children }: BottomSheetPro
               if (info.offset.y > 100) onClose();
             }}
           >
-            <div className="sticky top-0 z-10 bg-white rounded-t-2xl pt-3 pb-2 px-4">
-              <div className="mx-auto mb-2 h-1 w-10 rounded-full bg-gray-300" />
+            <div className="sticky top-0 z-10 bg-surface rounded-t-xl pt-3 pb-2 px-4">
+              <div className="mx-auto mb-2 h-1 w-10 rounded-full bg-border-strong" />
               {title && (
-                <h2 className="text-lg font-bold text-gray-900">{title}</h2>
+                <h2 className="text-lg font-bold text-foreground">{title}</h2>
               )}
             </div>
             <div className="px-4 pb-8">{children}</div>

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -12,18 +12,18 @@ interface ButtonProps extends ButtonHTMLAttributes<HTMLButtonElement> {
 
 const variantStyles: Record<ButtonVariant, string> = {
   primary:
-    "bg-indigo-600 text-white hover:bg-indigo-700 active:bg-indigo-800",
+    "bg-primary text-white hover:bg-primary-dark active:bg-primary-dark",
   secondary:
-    "bg-gray-100 text-gray-900 hover:bg-gray-200 active:bg-gray-300",
+    "bg-surface-strong text-foreground hover:bg-border-strong active:bg-border-strong",
   ghost:
-    "bg-transparent text-gray-700 hover:bg-gray-100 active:bg-gray-200",
+    "bg-transparent text-foreground hover:bg-surface-strong active:bg-border-strong",
   danger:
-    "bg-red-600 text-white hover:bg-red-700 active:bg-red-800",
+    "bg-danger text-white hover:opacity-90 active:opacity-80",
 };
 
 const sizeStyles: Record<ButtonSize, string> = {
   sm: "px-3 py-1.5 text-sm",
-  md: "px-4 py-2.5 text-base",
+  md: "px-4 py-2 text-base",
   lg: "px-6 py-3 text-lg",
 };
 
@@ -33,7 +33,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       <button
         ref={ref}
         disabled={disabled}
-        className={`inline-flex items-center justify-center rounded-lg font-semibold transition-colors disabled:opacity-50 disabled:pointer-events-none ${variantStyles[variant]} ${sizeStyles[size]} ${className}`}
+        className={`inline-flex items-center justify-center rounded font-semibold transition-colors disabled:opacity-50 disabled:pointer-events-none ${variantStyles[variant]} ${sizeStyles[size]} ${className}`}
         {...props}
       >
         {children}

--- a/src/components/ui/confirm-dialog.tsx
+++ b/src/components/ui/confirm-dialog.tsx
@@ -60,8 +60,8 @@ export function ConfirmDialog({
 
   const confirmClass =
     variant === "destructive"
-      ? "bg-red-500 hover:bg-red-600 text-white"
-      : "bg-indigo-500 hover:bg-indigo-600 text-white";
+      ? "bg-danger hover:opacity-90 text-white"
+      : "bg-primary hover:bg-primary-dark text-white";
 
   return (
     <AnimatePresence>
@@ -81,7 +81,7 @@ export function ConfirmDialog({
             onClick={onCancel}
           />
           <motion.div
-            className="relative w-full max-w-sm rounded-2xl bg-white p-5 shadow-xl"
+            className="relative w-full max-w-sm rounded-xl bg-surface border border-border p-5 shadow-md"
             initial={{ opacity: 0, scale: 0.95, y: 12 }}
             animate={{ opacity: 1, scale: 1, y: 0 }}
             exit={{ opacity: 0, scale: 0.95, y: 12 }}
@@ -89,14 +89,14 @@ export function ConfirmDialog({
           >
             <h2
               id="confirm-dialog-title"
-              className="text-lg font-bold text-gray-900"
+              className="text-lg font-bold text-foreground"
             >
               {title}
             </h2>
             {description && (
               <p
                 id="confirm-dialog-description"
-                className="mt-2 text-sm leading-relaxed text-gray-600"
+                className="mt-2 text-sm leading-relaxed text-muted"
               >
                 {description}
               </p>
@@ -105,7 +105,7 @@ export function ConfirmDialog({
               <button
                 type="button"
                 onClick={onConfirm}
-                className={`min-h-[48px] rounded-xl font-bold transition-colors ${confirmClass}`}
+                className={`min-h-[48px] rounded font-semibold transition-colors ${confirmClass}`}
               >
                 {confirmLabel}
               </button>
@@ -113,7 +113,7 @@ export function ConfirmDialog({
                 ref={cancelButtonRef}
                 type="button"
                 onClick={onCancel}
-                className="min-h-[48px] rounded-xl bg-gray-100 font-medium text-gray-800 transition-colors hover:bg-gray-200"
+                className="min-h-[48px] rounded bg-surface-strong font-medium text-foreground transition-colors hover:bg-border-strong"
               >
                 {cancelLabel}
               </button>

--- a/src/components/ui/fab.tsx
+++ b/src/components/ui/fab.tsx
@@ -16,7 +16,7 @@ export function Fab({ onClick }: FabProps) {
       whileHover={{ scale: 1.1 }}
       whileTap={{ rotate: 45, scale: 0.9 }}
       transition={{ type: "spring", damping: 20, stiffness: 300 }}
-      className="fixed bottom-6 right-6 z-40 flex h-14 w-14 items-center justify-center rounded-full bg-indigo-600 text-white shadow-lg"
+      className="fixed bottom-6 right-6 z-40 flex h-14 w-14 items-center justify-center rounded-full bg-primary text-white shadow-md"
       aria-label="タスクを追加"
     >
       <Plus size={28} />

--- a/src/components/ui/input.tsx
+++ b/src/components/ui/input.tsx
@@ -12,19 +12,19 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(
     return (
       <div className="flex flex-col gap-1.5">
         {label && (
-          <label htmlFor={id} className="text-sm font-medium text-gray-700">
+          <label htmlFor={id} className="text-sm font-medium text-foreground">
             {label}
           </label>
         )}
         <input
           ref={ref}
           id={id}
-          className={`rounded-lg border px-4 py-3 text-base outline-none transition-colors focus:border-indigo-500 focus:ring-2 focus:ring-indigo-500/20 ${
-            error ? "border-red-400" : "border-gray-300"
+          className={`rounded border bg-surface px-4 py-3 text-base text-foreground placeholder:text-subtle outline-none transition-colors focus:border-focus focus:ring-2 focus:ring-focus/15 ${
+            error ? "border-danger" : "border-border-strong"
           } ${className}`}
           {...props}
         />
-        {error && <p className="text-sm text-red-600">{error}</p>}
+        {error && <p className="text-sm text-danger">{error}</p>}
       </div>
     );
   }

--- a/src/components/ui/modal.tsx
+++ b/src/components/ui/modal.tsx
@@ -37,7 +37,7 @@ export function Modal({ isOpen, onClose, title, children }: ModalProps) {
             onClick={onClose}
           />
           <motion.div
-            className="relative w-full max-w-lg bg-white rounded-t-2xl sm:rounded-2xl max-h-[90dvh] overflow-y-auto"
+            className="relative w-full max-w-lg bg-surface rounded-t-xl sm:rounded-xl border border-border max-h-[90dvh] overflow-y-auto"
             initial={{ y: "100%" }}
             animate={{ y: 0 }}
             exit={{ y: "100%" }}
@@ -49,10 +49,10 @@ export function Modal({ isOpen, onClose, title, children }: ModalProps) {
               if (info.offset.y > 100) onClose();
             }}
           >
-            <div className="sticky top-0 z-10 bg-white rounded-t-2xl pt-3 pb-2 px-4">
-              <div className="mx-auto mb-2 h-1 w-10 rounded-full bg-gray-300" />
+            <div className="sticky top-0 z-10 bg-surface rounded-t-xl pt-3 pb-2 px-4">
+              <div className="mx-auto mb-2 h-1 w-10 rounded-full bg-border-strong" />
               {title && (
-                <h2 className="text-lg font-bold text-gray-900">{title}</h2>
+                <h2 className="text-lg font-bold text-foreground">{title}</h2>
               )}
             </div>
             <div className="px-4 pb-8">{children}</div>


### PR DESCRIPTION
getdesign の Notion DESIGN.md を取り込み、Indigo 一辺倒の配色から
warm neutral + Notion blue + whisper border のニュートラルな
ライト UI に置き換えた。色・フォント・角丸のみを対象とし、
レイアウト構造（CategoryTabs 等）は据え置き。

- DESIGN.md: npx getdesign@latest add notion で生成
- globals.css: warm neutral / Notion blue / whisper border の
  セマンティックトークンを CSS 変数 + @theme inline で公開
- layout.tsx: フォントを Geist Sans → Inter に切替、theme-color 更新
- UI primitives と各画面のクラスを意味カラー（bg-surface,
  text-foreground, border-border 等）へ機械的に差し替え
- task-item.tsx: 期日左ボーダーを 4px → 2px、彩度を Notion 寄りに減色