### PR TITLE
fix: PWA アイコンを最新版に更新するためキャッシュバスターを bump

### DIFF
--- a/public/manifest.json
+++ b/public/manifest.json
@@ -9,49 +9,49 @@
   "orientation": "portrait",
   "icons": [
     {
-      "src": "/icon-48x48.png?v=2",
+      "src": "/icon-48x48.png?v=3",
       "sizes": "48x48",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "/icon-72x72.png?v=2",
+      "src": "/icon-72x72.png?v=3",
       "sizes": "72x72",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "/icon-96x96.png?v=2",
+      "src": "/icon-96x96.png?v=3",
       "sizes": "96x96",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "/icon-144x144.png?v=2",
+      "src": "/icon-144x144.png?v=3",
       "sizes": "144x144",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "/icon-192x192.png?v=2",
+      "src": "/icon-192x192.png?v=3",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "/icon-512x512.png?v=2",
+      "src": "/icon-512x512.png?v=3",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "/icon-maskable-192x192.png?v=2",
+      "src": "/icon-maskable-192x192.png?v=3",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "maskable"
     },
     {
-      "src": "/icon-maskable-512x512.png?v=2",
+      "src": "/icon-maskable-512x512.png?v=3",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,4 +1,4 @@
-const SW_VERSION = "3";
+const SW_VERSION = "4";
 
 self.addEventListener("install", () => {
   // Activate immediately without waiting for existing tabs to close
@@ -15,8 +15,8 @@ self.addEventListener("push", (event) => {
   const title = data.title || "家族タスク";
   const options = {
     body: data.body || "",
-    icon: "/icon-192x192.png",
-    badge: "/icon-badge.png",
+    icon: "/icon-192x192.png?v=3",
+    badge: "/icon-badge.png?v=3",
     data: {
       url: data.url || "/",
     },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,12 +20,12 @@ export const metadata: Metadata = {
   manifest: "/manifest.json",
   icons: {
     icon: [
-      { url: "/favicon.png", sizes: "32x32", type: "image/png" },
-      { url: "/icon-96x96.png", sizes: "96x96", type: "image/png" },
-      { url: "/icon-192x192.png", sizes: "192x192", type: "image/png" },
+      { url: "/favicon.png?v=3", sizes: "32x32", type: "image/png" },
+      { url: "/icon-96x96.png?v=3", sizes: "96x96", type: "image/png" },
+      { url: "/icon-192x192.png?v=3", sizes: "192x192", type: "image/png" },
     ],
     apple: [
-      { url: "/apple-touch-icon.png", sizes: "180x180", type: "image/png" },
+      { url: "/apple-touch-icon.png?v=3", sizes: "180x180", type: "image/png" },
     ],
   },
   appleWebApp: {


### PR DESCRIPTION
Android Chrome の WebAPK は manifest のバイト変化を検知して初めて
ホーム画面アイコンを再生成する。アイコン画像ファイル自体を差し替えた
だけでは manifest 内の URL クエリが ?v=2 のまま不変で、Chrome が
更新を検知できなかった。

- manifest.json の全 icons[].src を ?v=2 → ?v=3 に bump
- sw.js の SW_VERSION を 3 → 4 に bump
- sw.js の push 通知 icon/badge にも ?v=3 を付与
- layout.tsx の metadata.icons の URL に ?v=3 を付与

これで Chrome の定期チェック（24時間〜数日）で WebAPK が再生成され
ホーム画面アイコンが新画像に置き換わる。即時反映が必要なユーザーには
PWA の再インストールを案内する。

https://claude.ai/code/session_01CsKPQdTczHGUfRdDVbZQEN