### PR TITLE
docs: CLAUDE.md をコードベースの実態に合わせて更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,9 +16,10 @@
 | Push | web-push 3.6（VAPID） |
 | Language | TypeScript 5（strict） |
 | Lint | ESLint 9 + eslint-config-next |
+| Test | Vitest 2 |
 | Pkg Manager | npm |
 
-自動テストは未導入（`npm test` スクリプトなし）。品質チェックは ESLint のみ。
+品質チェックは ESLint および Vitest による自動テスト。テストファイルは `src/hooks/` および `src/components/` 配下に配置。
 
 ---
 
@@ -29,6 +30,8 @@ npm run dev          # Next.js 開発サーバー（http://localhost:3000）
 npm run build        # 本番ビルド
 npm run start        # 本番サーバー
 npm run lint         # ESLint
+npm test             # Vitest（watch モード）
+npm run test:run     # Vitest（単発実行・CI 用）
 
 npx supabase start   # ローカル Supabase 起動（要 Docker Desktop）
 npx supabase stop    # 停止
@@ -56,6 +59,7 @@ npx supabase db push                            # 本番 Supabase へ反映
   - `client.ts` — Client Component 用（`createBrowserClient`）
   - `server.ts` — Server Component / Route Handler 用（`createServerClient` + cookies）
   - `middleware.ts` — proxy 専用のセッション更新ロジック
+  - `service-role.ts` — サービスロールキー用クライアント。`src/app/api/push/send/route.ts` でのみ使用
 - `src/app/api/push/` — Web Push の Route Handler。`subscribe/` は購読登録/削除、`send/` は他メンバーへの通知送信。`useTasks` のタスク追加・完了時に呼ばれる。
 - `src/app/auth/callback/route.ts` — Supabase OAuth / マジックリンクの code→session 交換。
 - `supabase/templates/`, `supabase/snippets/` — Supabase のメール / SQL テンプレート置き場（手動編集対象）。
@@ -95,6 +99,7 @@ VAPID_SUBJECT=mailto:...
 | `task_assignees` | tasks ↔ profiles の N:N |
 | `task_images` | タスク画像の Storage パス |
 | `push_subscriptions` | Web Push 購読情報（profile に紐づく） |
+| `dismissed_recommendations` | ユーザーが非表示にしたレコメンドの記録（household_id / profile_id / normalized_title / dismissed_until） |
 
 主要な DB 関数（`supabase.rpc()` で呼べる）：
 - `get_my_household_id()` — RLS の無限再帰回避用 SECURITY DEFINER ヘルパ
@@ -102,12 +107,15 @@ VAPID_SUBJECT=mailto:...
 - `generate_invite_code(p_household_id)` — 6 文字招待コード生成
 - `reorder_tasks(p_task_ids, p_sort_orders)` — タスク並び順の一括更新（RLS 対応）
 - `handle_new_user()` / `handle_updated_at()` — トリガ関数
+- `verify_invite_code(p_code text)` — 招待コード検証（有効期限チェック）
+- `get_recurring_recommendations()` — 定期タスクレコメンド取得（引数なし、`get_my_household_id()` で自動スコープ）
+- `join_household_with_code(p_code text)` — 招待コード検証 + `profiles.household_id` 更新をアトミックに実行
 
 `tasks` と `categories` は `supabase_realtime` に publish されており、`useRealtimeTasks` が世帯単位で購読する。
 
 ### マイグレーション一覧
 
-`supabase/migrations/` 配下に 9 ファイル：
+`supabase/migrations/` 配下に 11 ファイル：
 
 1. `001_initial_schema.sql` — 全スキーマ + RLS + トリガ + 関数
 2. `002_add_profiles_insert_policy.sql`
@@ -118,6 +126,8 @@ VAPID_SUBJECT=mailto:...
 7. `007_security_hardening.sql`
 8. `008_security_and_performance_fixes.sql`
 9. `009_tasks_replica_identity_full.sql`
+10. `010_recurring_recommendations.sql` — `dismissed_recommendations` テーブル追加、`get_recurring_recommendations` RPC 新設
+11. `011_restore_rpc_auth_checks.sql` — RPC 認可チェック復元、`get_recurring_recommendations` を引数なしに再定義、`join_household_with_code` RPC 新設
 
 ---
 
@@ -133,6 +143,7 @@ VAPID_SUBJECT=mailto:...
 
 - `docs/incident-profiles-403.md` — profiles テーブルへの 403 エラーに関する過去インシデント記録（RLS 設計の経緯把握に有用）
 - `docs/nonfunctional-roadmap.md` — 非機能要件（パフォーマンス・セキュリティ・運用）のロードマップ
+- `docs/performance-analysis.md` — パフォーマンス分析記録
 
 ルートにある `plan.md` は機能開発の計画メモ。
 


### PR DESCRIPTION
以下の乖離を解消：
- テスト環境（Vitest 2）の追加：「未導入」の誤記を修正、コマンド追記
- lib/supabase/service-role.ts を構成補足に追記
- スキーマに dismissed_recommendations テーブルを追加
- 主要 DB 関数に verify_invite_code / get_recurring_recommendations / join_household_with_code を追記
- マイグレーション一覧を 9→11 件に更新（010・011 追記）
- docs/performance-analysis.md を docs/ 説明に追記

https://claude.ai/code/session_01EfhqWaiAGoCRHX9pSTXFwn