### PR TITLE
feat: タブレット（iPad）レイアウト最適化

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -226,7 +226,7 @@ export default function Home() {
       </header>
 
       {/* Task List */}
-      <main className="pt-2">
+      <main className="pt-2 mx-auto w-full md:max-w-2xl">
         {!tasksLoading && !recsLoading && recommendations.length > 0 && (
           <RecommendationSection
             recommendations={recommendations}

--- a/src/components/ui/bottom-sheet.tsx
+++ b/src/components/ui/bottom-sheet.tsx
@@ -12,6 +12,15 @@ interface BottomSheetProps {
 
 export function BottomSheet({ isOpen, onClose, title, children }: BottomSheetProps) {
   const [keyboardHeight, setKeyboardHeight] = useState(0);
+  const [isTablet, setIsTablet] = useState(false);
+
+  useEffect(() => {
+    const mq = window.matchMedia("(min-width: 768px)");
+    setIsTablet(mq.matches);
+    const handler = (e: MediaQueryListEvent) => setIsTablet(e.matches);
+    mq.addEventListener("change", handler);
+    return () => mq.removeEventListener("change", handler);
+  }, []);
 
   useEffect(() => {
     if (isOpen) {
@@ -56,7 +65,7 @@ export function BottomSheet({ isOpen, onClose, title, children }: BottomSheetPro
   return (
     <AnimatePresence>
       {isOpen && (
-        <div className="fixed inset-0 z-50 flex items-end justify-center">
+        <div className="fixed inset-0 z-50 flex items-end md:items-center justify-center">
           <motion.div
             className="absolute inset-0 bg-black/40"
             initial={{ opacity: 0 }}
@@ -65,26 +74,28 @@ export function BottomSheet({ isOpen, onClose, title, children }: BottomSheetPro
             onClick={onClose}
           />
           <motion.div
-            className="relative w-full max-w-lg bg-surface rounded-t-xl border border-border overflow-y-auto"
+            className="relative w-full max-w-lg bg-surface rounded-t-xl md:rounded-xl border border-border overflow-y-auto"
             style={{
-              maxHeight: effectiveKeyboardHeight > 0
+              maxHeight: !isTablet && effectiveKeyboardHeight > 0
                 ? `calc(100dvh - ${effectiveKeyboardHeight}px - 40px)`
                 : "80dvh",
-              marginBottom: effectiveKeyboardHeight > 0 ? `${effectiveKeyboardHeight}px` : 0,
+              marginBottom: !isTablet && effectiveKeyboardHeight > 0
+                ? `${effectiveKeyboardHeight}px`
+                : 0,
             }}
             initial={{ y: "100%" }}
             animate={{ y: 0 }}
             exit={{ y: "100%" }}
             transition={{ type: "spring", damping: 25, stiffness: 300 }}
-            drag="y"
-            dragConstraints={{ top: 0 }}
-            dragElastic={0.2}
-            onDragEnd={(_, info) => {
+            drag={isTablet ? false : "y"}
+            dragConstraints={isTablet ? undefined : { top: 0 }}
+            dragElastic={isTablet ? undefined : 0.2}
+            onDragEnd={isTablet ? undefined : (_, info) => {
               if (info.offset.y > 100) onClose();
             }}
           >
             <div className="sticky top-0 z-10 bg-surface rounded-t-xl pt-3 pb-2 px-4">
-              <div className="mx-auto mb-2 h-1 w-10 rounded-full bg-border-strong" />
+              <div className="mx-auto mb-2 h-1 w-10 rounded-full bg-border-strong md:hidden" />
               {title && (
                 <h2 className="text-lg font-bold text-foreground">{title}</h2>
               )}


### PR DESCRIPTION
- BottomSheet: md以上でボトムシートを中央ダイアログに切り替え
  - items-end → md:items-center でセンタリング
  - rounded-t-xl → md:rounded-xl で全角丸
  - isTablet検知でドラッグ無効化・ドラッグハンドル非表示
  - キーボードoffsetロジック（marginBottom/maxHeight）をmobile専用に限定
    interactiveWidget:resizes-contentによりtabletはdvh自体が縮小するため不要
- page.tsx: mainにmd:max-w-2xlを追加してコンテンツカラムを中央揃え