### PR TITLE
perf: タスク追加後のラグを改善

### DIFF
--- a/src/components/ui/bottom-sheet.tsx
+++ b/src/components/ui/bottom-sheet.tsx
@@ -84,9 +84,8 @@ export function BottomSheet({ isOpen, onClose, title, children }: BottomSheetPro
                 : 0,
             }}
             initial={{ y: "100%" }}
-            animate={{ y: 0 }}
-            exit={{ y: "100%" }}
-            transition={{ type: "spring", damping: 25, stiffness: 300 }}
+            animate={{ y: 0, transition: { type: "spring", damping: 25, stiffness: 300 } }}
+            exit={{ y: "100%", transition: { type: "tween", duration: 0.18, ease: "easeIn" } }}
             drag={isTablet ? false : "y"}
             dragConstraints={isTablet ? undefined : { top: 0 }}
             dragElastic={isTablet ? undefined : 0.2}

--- a/src/hooks/use-tasks.ts
+++ b/src/hooks/use-tasks.ts
@@ -105,10 +105,11 @@ export function useTasks(householdId: string | null) {
     }
 
     // Optimistic update
-    const previousTasks = tasks;
-    setTasks((prev) =>
-      prev.map((t) => (t.id === id ? { ...t, ...updates } : t))
-    );
+    let snapshot = tasks;
+    setTasks((prev) => {
+      snapshot = prev;
+      return prev.map((t) => (t.id === id ? { ...t, ...updates } : t));
+    });
 
     const { data, error } = await supabase
       .from("tasks")
@@ -119,7 +120,7 @@ export function useTasks(householdId: string | null) {
 
     if (error) {
       // Rollback
-      setTasks(previousTasks);
+      setTasks(snapshot);
       toast.error("タスクの更新に失敗しました");
     } else if (data) {
       // Sync with server data
@@ -188,7 +189,9 @@ export function useTasks(householdId: string | null) {
 
   const reorderTasks = async (orderedIds: string[]) => {
     // Optimistic update
+    let snapshot = tasks;
     setTasks((prev) => {
+      snapshot = prev;
       const idToTask = new Map(prev.map((t) => [t.id, t]));
       const reordered = orderedIds.map((id, i) => ({ ...idToTask.get(id)!, sort_order: i }));
       const rest = prev.filter((t) => !orderedIds.includes(t.id));
@@ -199,7 +202,10 @@ export function useTasks(householdId: string | null) {
       p_task_ids: orderedIds,
       p_sort_orders: orderedIds.map((_, i) => i),
     });
-    if (error) toast.error("タスクの並び替えに失敗しました");
+    if (error) {
+      setTasks(snapshot);
+      toast.error("タスクの並び替えに失敗しました");
+    }
   };
 
   return { tasks, setTasks, loading, addTask, updateTask, deleteTask, toggleTask, reorderTasks, refetch: fetchTasks };


### PR DESCRIPTION
BottomSheet の exit アニメーションを spring から tween(0.18s) に変更し、
シートが閉じるまでの視覚的ラグを短縮。楽観的更新済みのタスクが
アニメーション完了後すぐ見えるようになる。

併せて updateTask・reorderTasks の楽観的更新ロールバック処理を改善:
- updateTask: previousTasks をクロージャ変数から setTasks コールバック内
  の prev でキャプチャするよう変更（stale closure 回避）
- reorderTasks: エラー時のロールバックが未実装だったため追加

https://claude.ai/code/session_012VAfTfCpZa32gsFL9YmzX4