### PR TITLE
feat: 定番品(staple_items)機能を追加

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,7 +2,8 @@
 
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
-import { Settings, ArrowUpDown, Check } from "lucide-react";
+import { Settings, ArrowUpDown, Check, BookMarked } from "lucide-react";
+import { motion } from "framer-motion";
 import { toast } from "sonner";
 import { createClient } from "@/lib/supabase/client";
 import { CategoryTabs } from "@/components/category/category-tabs";
@@ -19,9 +20,12 @@ import { useCategories } from "@/hooks/use-categories";
 import { useRealtimeTasks } from "@/hooks/use-realtime-tasks";
 import { useSort, SORT_OPTIONS } from "@/hooks/use-sort";
 import { BottomSheet } from "@/components/ui/bottom-sheet";
+import { StapleItemsSheet } from "@/components/staple/staple-items-sheet";
 import { useTaskRecommendations } from "@/hooks/use-task-recommendations";
 import { useTitleSuggestions } from "@/hooks/use-title-suggestions";
 import { usePageData } from "@/hooks/use-page-data";
+import { useStapleItems } from "@/hooks/use-staple-items";
+import { useRealtimeStapleItems } from "@/hooks/use-realtime-staple-items";
 import type { TabMeasurements } from "@/components/category/category-tabs";
 import type { IndicatorRefs } from "@/hooks/use-swipeable-tab";
 import type { Task, TaskRecommendation } from "@/types";
@@ -31,6 +35,7 @@ export default function Home() {
   const { profile, members, householdName, loading } = usePageData();
   const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(null);
   const [isCreateOpen, setIsCreateOpen] = useState(false);
+  const [isStapleOpen, setIsStapleOpen] = useState(false);
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [isSortOpen, setIsSortOpen] = useState(false);
   const { sortOption, setSortOption } = useSort();
@@ -62,6 +67,18 @@ export default function Home() {
   const { recommendations, loading: recsLoading, dismiss: dismissRecommendation, refetch: refetchRecommendations } =
     useTaskRecommendations(householdId, profile?.id);
   const { getSuggestions } = useTitleSuggestions(householdId);
+
+  const {
+    stapleItems,
+    setStapleItems,
+    loading: stapleLoading,
+    addStapleItem,
+    updateStapleItem,
+    deleteStapleItem,
+    reorderStapleItems,
+    recordUsage,
+  } = useStapleItems(householdId);
+  useRealtimeStapleItems(householdId, setStapleItems);
 
   // Debounced refetch for realtime events from other household members
   const recsTimerRef = useRef<NodeJS.Timeout | null>(null);
@@ -260,6 +277,20 @@ export default function Home() {
         </SwipeableTaskContainer>
       </main>
 
+      {/* 定番品ボタン */}
+      <motion.button
+        onClick={() => setIsStapleOpen(true)}
+        initial={{ y: 64, opacity: 0 }}
+        animate={{ y: 0, opacity: 1 }}
+        whileHover={{ scale: 1.1 }}
+        whileTap={{ scale: 0.9 }}
+        transition={{ type: "spring", damping: 20, stiffness: 300 }}
+        className="fixed bottom-6 right-24 z-40 flex h-12 w-12 items-center justify-center rounded-full bg-surface border border-border text-foreground shadow-md"
+        aria-label="定番品"
+      >
+        <BookMarked size={20} />
+      </motion.button>
+
       {/* FAB */}
       <Fab onClick={() => setIsCreateOpen(true)} />
 
@@ -282,6 +313,23 @@ export default function Home() {
         members={members}
         onUpdate={handleUpdate}
         onDelete={handleDeleteTask}
+      />
+
+      {/* Staple Items Sheet */}
+      <StapleItemsSheet
+        isOpen={isStapleOpen}
+        onClose={() => setIsStapleOpen(false)}
+        stapleItems={stapleItems}
+        loading={stapleLoading}
+        categories={categories}
+        selectedCategoryId={selectedCategoryId}
+        profileId={profile?.id ?? null}
+        onAddToTask={(task) => addTask({ ...task, created_by: profile?.id ?? null })}
+        onAddStapleItem={addStapleItem}
+        onUpdateStapleItem={updateStapleItem}
+        onDeleteStapleItem={deleteStapleItem}
+        onReorderStapleItems={reorderStapleItems}
+        onRecordUsage={recordUsage}
       />
 
       {/* Sort Sheet */}

--- a/src/components/staple/staple-item-card.tsx
+++ b/src/components/staple/staple-item-card.tsx
@@ -1,0 +1,118 @@
+"use client";
+
+import { useRef } from "react";
+import { motion } from "framer-motion";
+import { X, ShoppingCart } from "lucide-react";
+import type { StapleItem, Category } from "@/types";
+
+interface StapleItemCardProps {
+  item: StapleItem;
+  categories: Category[];
+  isEditMode: boolean;
+  onAddToTask: (item: StapleItem) => void;
+  onLongPress: (item: StapleItem) => void;
+  onDelete: (id: string) => void;
+  isDragging?: boolean;
+}
+
+function formatQuantity(quantity: number | null, unit: string | null): string {
+  if (quantity === null) return "";
+  const q = Number.isInteger(quantity) ? quantity.toString() : quantity.toString();
+  return unit ? `${q}${unit}` : q;
+}
+
+export function StapleItemCard({
+  item,
+  isEditMode,
+  onAddToTask,
+  onLongPress,
+  onDelete,
+  isDragging = false,
+}: StapleItemCardProps) {
+  const longPressTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const isLongPress = useRef(false);
+
+  const handlePointerDown = () => {
+    if (isEditMode) return;
+    isLongPress.current = false;
+    longPressTimer.current = setTimeout(() => {
+      isLongPress.current = true;
+      onLongPress(item);
+    }, 500);
+  };
+
+  const handlePointerUp = () => {
+    if (longPressTimer.current) {
+      clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+    if (!isLongPress.current && !isEditMode) {
+      onAddToTask(item);
+    }
+  };
+
+  const handlePointerLeave = () => {
+    if (longPressTimer.current) {
+      clearTimeout(longPressTimer.current);
+      longPressTimer.current = null;
+    }
+  };
+
+  const qtyText = formatQuantity(item.default_quantity, item.default_unit);
+
+  return (
+    <motion.div
+      className="relative"
+      animate={
+        isEditMode
+          ? { rotate: [-1, 1, -1, 1, 0] }
+          : { rotate: 0 }
+      }
+      transition={
+        isEditMode
+          ? { repeat: Infinity, duration: 0.35, ease: "easeInOut" }
+          : { duration: 0.15 }
+      }
+    >
+      {isEditMode && (
+        <button
+          onClick={() => onDelete(item.id)}
+          className="absolute -top-2 -left-2 z-10 flex h-5 w-5 items-center justify-center rounded-full bg-destructive text-white shadow"
+          aria-label={`${item.name}を削除`}
+        >
+          <X size={12} />
+        </button>
+      )}
+
+      <button
+        onPointerDown={handlePointerDown}
+        onPointerUp={handlePointerUp}
+        onPointerLeave={handlePointerLeave}
+        onContextMenu={(e) => e.preventDefault()}
+        onClick={isEditMode ? () => onLongPress(item) : undefined}
+        disabled={isDragging}
+        className={[
+          "flex w-full flex-col items-center gap-1.5 rounded-xl border px-2 py-3 text-center transition-colors",
+          "bg-surface border-border active:bg-surface-strong",
+          isEditMode ? "cursor-default" : "cursor-pointer",
+          isDragging ? "opacity-50 shadow-lg" : "",
+        ].join(" ")}
+      >
+        <span className="text-2xl leading-none" aria-hidden>
+          {item.icon ?? <ShoppingCart size={20} className="text-muted" />}
+        </span>
+        <span className="w-full truncate text-xs font-medium text-foreground leading-tight">
+          {item.name}
+        </span>
+        {qtyText && (
+          <span className="text-[10px] text-muted leading-none">{qtyText}</span>
+        )}
+        {item.use_count > 0 && (
+          <span className="rounded-full bg-primary/10 px-1.5 py-0.5 text-[10px] font-medium text-primary leading-none">
+            {item.use_count}回
+          </span>
+        )}
+      </button>
+    </motion.div>
+  );
+}

--- a/src/components/staple/staple-item-form-sheet.tsx
+++ b/src/components/staple/staple-item-form-sheet.tsx
@@ -1,0 +1,191 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { BottomSheet } from "@/components/ui/bottom-sheet";
+import { Button } from "@/components/ui/button";
+import { CategoryPicker } from "@/components/task/category-picker";
+import type { Category, StapleItem } from "@/types";
+
+const UNIT_OPTIONS = ["個", "本", "枚", "袋", "箱", "パック", "缶", "瓶", "束", "玉", "g", "kg", "ml", "L"];
+
+const ICON_PRESETS = [
+  "🛒", "🥛", "🥚", "🍞", "🧈", "🧀", "🍖", "🍗", "🐟", "🦐",
+  "🥦", "🥕", "🍅", "🧅", "🧄", "🍋", "🍎", "🍌", "🍜", "🍣",
+  "🍙", "🥞", "🧃", "🍵", "☕", "🧴", "🧻", "🪥", "🧺", "🧹",
+];
+
+interface StapleItemFormSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  categories: Category[];
+  item?: StapleItem | null;
+  defaultCategoryId?: string | null;
+  onSubmit: (data: {
+    name: string;
+    category_id: string | null;
+    default_quantity: number | null;
+    default_unit: string | null;
+    note: string | null;
+    icon: string | null;
+  }) => void;
+}
+
+export function StapleItemFormSheet({
+  isOpen,
+  onClose,
+  categories,
+  item,
+  defaultCategoryId,
+  onSubmit,
+}: StapleItemFormSheetProps) {
+  const [name, setName] = useState("");
+  const [icon, setIcon] = useState("");
+  const [categoryId, setCategoryId] = useState<string | null>(null);
+  const [quantityStr, setQuantityStr] = useState("");
+  const [unit, setUnit] = useState("");
+  const [note, setNote] = useState("");
+  const [showIconPicker, setShowIconPicker] = useState(false);
+
+  useEffect(() => {
+    if (isOpen) {
+      if (item) {
+        setName(item.name);
+        setIcon(item.icon ?? "");
+        setCategoryId(item.category_id);
+        setQuantityStr(item.default_quantity !== null ? String(item.default_quantity) : "");
+        setUnit(item.default_unit ?? "");
+        setNote(item.note ?? "");
+      } else {
+        setName("");
+        setIcon("");
+        setCategoryId(defaultCategoryId ?? null);
+        setQuantityStr("");
+        setUnit("");
+        setNote("");
+      }
+      setShowIconPicker(false);
+    }
+  }, [isOpen, item, defaultCategoryId]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!name.trim()) return;
+
+    const quantity = quantityStr ? parseFloat(quantityStr) : null;
+
+    onSubmit({
+      name: name.trim(),
+      category_id: categoryId,
+      default_quantity: quantity !== null && !isNaN(quantity) ? quantity : null,
+      default_unit: unit.trim() || null,
+      note: note.trim() || null,
+      icon: icon || null,
+    });
+
+    onClose();
+  };
+
+  const title = item ? "定番品を編集" : "定番品を追加";
+
+  return (
+    <BottomSheet isOpen={isOpen} onClose={onClose} title={title} elevated>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        {/* アイコン + 名前 */}
+        <div className="flex items-center gap-3">
+          <button
+            type="button"
+            onClick={() => setShowIconPicker((v) => !v)}
+            className="flex h-12 w-12 shrink-0 items-center justify-center rounded-xl border border-border bg-surface text-2xl"
+            aria-label="アイコンを選択"
+          >
+            {icon || "🛒"}
+          </button>
+          <input
+            value={name}
+            onChange={(e) => setName(e.target.value)}
+            placeholder="定番品の名前"
+            maxLength={255}
+            autoFocus
+            autoComplete="off"
+            className="flex-1 rounded border border-border-strong bg-surface px-4 py-3 text-base text-foreground placeholder:text-subtle outline-none focus:border-focus focus:ring-2 focus:ring-focus/15"
+          />
+        </div>
+
+        {showIconPicker && (
+          <div className="grid grid-cols-8 gap-2 rounded-xl border border-border bg-surface-strong p-3">
+            {ICON_PRESETS.map((emoji) => (
+              <button
+                key={emoji}
+                type="button"
+                onClick={() => {
+                  setIcon(emoji);
+                  setShowIconPicker(false);
+                }}
+                className={`flex h-9 w-9 items-center justify-center rounded-lg text-xl transition-colors ${icon === emoji ? "bg-primary/20" : "hover:bg-surface active:bg-border"}`}
+              >
+                {emoji}
+              </button>
+            ))}
+            <button
+              type="button"
+              onClick={() => {
+                setIcon("");
+                setShowIconPicker(false);
+              }}
+              className="col-span-2 rounded-lg px-2 py-1 text-xs text-muted hover:bg-surface active:bg-border"
+            >
+              リセット
+            </button>
+          </div>
+        )}
+
+        <CategoryPicker
+          categories={categories}
+          selectedId={categoryId}
+          onChange={setCategoryId}
+        />
+
+        {/* 数量・単位 */}
+        <div className="flex items-center gap-2">
+          <div className="flex-1">
+            <input
+              type="number"
+              inputMode="decimal"
+              value={quantityStr}
+              onChange={(e) => setQuantityStr(e.target.value)}
+              placeholder="数量（任意）"
+              min="0"
+              step="0.5"
+              className="w-full rounded border border-border-strong bg-surface px-4 py-3 text-sm text-foreground placeholder:text-subtle outline-none focus:border-focus focus:ring-2 focus:ring-focus/15"
+            />
+          </div>
+          <div className="w-28">
+            <select
+              value={unit}
+              onChange={(e) => setUnit(e.target.value)}
+              className="w-full rounded border border-border-strong bg-surface px-3 py-3 text-sm text-foreground outline-none focus:border-focus focus:ring-2 focus:ring-focus/15"
+            >
+              <option value="">単位なし</option>
+              {UNIT_OPTIONS.map((u) => (
+                <option key={u} value={u}>{u}</option>
+              ))}
+            </select>
+          </div>
+        </div>
+
+        <textarea
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder="メモ（銘柄・サイズなど、任意）"
+          maxLength={1000}
+          rows={2}
+          className="rounded border border-border-strong bg-surface px-4 py-3 text-sm text-foreground placeholder:text-subtle outline-none resize-none focus:border-focus focus:ring-2 focus:ring-focus/15"
+        />
+
+        <Button type="submit" disabled={!name.trim()}>
+          {item ? "保存" : "追加"}
+        </Button>
+      </form>
+    </BottomSheet>
+  );
+}

--- a/src/components/staple/staple-items-sheet.tsx
+++ b/src/components/staple/staple-items-sheet.tsx
@@ -1,0 +1,432 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { motion, AnimatePresence } from "framer-motion";
+import { Plus, Search, ShoppingBag } from "lucide-react";
+import {
+  DndContext,
+  closestCenter,
+  PointerSensor,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  useSortable,
+  rectSortingStrategy,
+  arrayMove,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { toast } from "sonner";
+import { BottomSheet } from "@/components/ui/bottom-sheet";
+import { StapleItemCard } from "@/components/staple/staple-item-card";
+import { StapleItemFormSheet } from "@/components/staple/staple-item-form-sheet";
+import type { StapleItem, Category } from "@/types";
+
+interface SortableStapleCardProps {
+  item: StapleItem;
+  categories: Category[];
+  isEditMode: boolean;
+  onAddToTask: (item: StapleItem) => void;
+  onLongPress: (item: StapleItem) => void;
+  onDelete: (id: string) => void;
+}
+
+function SortableStapleCard(props: SortableStapleCardProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: props.item.id,
+    disabled: !props.isEditMode,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} {...(props.isEditMode ? { ...attributes, ...listeners } : {})}>
+      <StapleItemCard {...props} isDragging={isDragging} />
+    </div>
+  );
+}
+
+interface QuickAddSheetProps {
+  isOpen: boolean;
+  item: StapleItem | null;
+  onClose: () => void;
+  onConfirm: (item: StapleItem, overrideQuantity: number | null, overrideNote: string | null) => void;
+}
+
+function QuickAddSheet({ isOpen, item, onClose, onConfirm }: QuickAddSheetProps) {
+  const [quantityStr, setQuantityStr] = useState("");
+  const [note, setNote] = useState("");
+
+  const handleOpen = useCallback(() => {
+    if (item) {
+      setQuantityStr(item.default_quantity !== null ? String(item.default_quantity) : "");
+      setNote(item.note ?? "");
+    }
+  }, [item]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!item) return;
+    const quantity = quantityStr ? parseFloat(quantityStr) : null;
+    onConfirm(item, quantity !== null && !isNaN(quantity) ? quantity : null, note.trim() || null);
+    onClose();
+  };
+
+  return (
+    <BottomSheet
+      isOpen={isOpen}
+      onClose={onClose}
+      title={item?.name ?? ""}
+      elevated
+    >
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4" onAnimationStart={handleOpen}>
+        <p className="text-sm text-muted">数量・メモを調整してリストに追加できます</p>
+        <div className="flex items-center gap-2">
+          <input
+            type="number"
+            inputMode="decimal"
+            value={quantityStr}
+            onChange={(e) => setQuantityStr(e.target.value)}
+            placeholder="数量"
+            min="0"
+            step="0.5"
+            className="flex-1 rounded border border-border-strong bg-surface px-4 py-3 text-sm text-foreground placeholder:text-subtle outline-none focus:border-focus focus:ring-2 focus:ring-focus/15"
+          />
+          {item?.default_unit && (
+            <span className="text-sm text-muted">{item.default_unit}</span>
+          )}
+        </div>
+        <textarea
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder="メモ（任意）"
+          rows={2}
+          maxLength={1000}
+          className="rounded border border-border-strong bg-surface px-4 py-3 text-sm text-foreground placeholder:text-subtle outline-none resize-none focus:border-focus focus:ring-2 focus:ring-focus/15"
+        />
+        <button
+          type="submit"
+          className="rounded-xl bg-primary px-4 py-3 text-sm font-semibold text-white active:bg-primary/90"
+        >
+          リストに追加
+        </button>
+      </form>
+    </BottomSheet>
+  );
+}
+
+interface StapleItemsSheetProps {
+  isOpen: boolean;
+  onClose: () => void;
+  stapleItems: StapleItem[];
+  loading: boolean;
+  categories: Category[];
+  selectedCategoryId: string | null;
+  profileId: string | null;
+  onAddToTask: (task: {
+    title: string;
+    category_id: string | null;
+    note: string | null;
+  }) => void;
+  onAddStapleItem: (data: {
+    name: string;
+    category_id?: string | null;
+    default_quantity?: number | null;
+    default_unit?: string | null;
+    note?: string | null;
+    icon?: string | null;
+    created_by?: string | null;
+  }) => void;
+  onUpdateStapleItem: (
+    id: string,
+    updates: Partial<Pick<StapleItem, "name" | "category_id" | "default_quantity" | "default_unit" | "note" | "icon" | "sort_order">>
+  ) => void;
+  onDeleteStapleItem: (id: string) => void;
+  onReorderStapleItems: (orderedIds: string[]) => void;
+  onRecordUsage: (id: string) => void;
+}
+
+function buildTaskTitle(item: StapleItem): string {
+  if (item.default_quantity === null) return item.name;
+  const q = Number.isInteger(item.default_quantity)
+    ? String(item.default_quantity)
+    : String(item.default_quantity);
+  const unit = item.default_unit ?? "";
+  return `${item.name} ${q}${unit}`.trim();
+}
+
+export function StapleItemsSheet({
+  isOpen,
+  onClose,
+  stapleItems,
+  loading,
+  categories,
+  selectedCategoryId,
+  profileId,
+  onAddToTask,
+  onAddStapleItem,
+  onUpdateStapleItem,
+  onDeleteStapleItem,
+  onReorderStapleItems,
+  onRecordUsage,
+}: StapleItemsSheetProps) {
+  const [isEditMode, setIsEditMode] = useState(false);
+  const [searchQuery, setSearchQuery] = useState("");
+  const [isFormOpen, setIsFormOpen] = useState(false);
+  const [editingItem, setEditingItem] = useState<StapleItem | null>(null);
+  const [quickAddItem, setQuickAddItem] = useState<StapleItem | null>(null);
+  const [isQuickAddOpen, setIsQuickAddOpen] = useState(false);
+  const [orderedIds, setOrderedIds] = useState<string[]>([]);
+
+  const sensors = useSensors(
+    useSensor(PointerSensor, { activationConstraint: { distance: 8 } })
+  );
+
+  const displayItems = searchQuery.trim()
+    ? stapleItems.filter((si) =>
+        si.name.toLowerCase().includes(searchQuery.toLowerCase())
+      )
+    : stapleItems;
+
+  const sortedItems = isEditMode && orderedIds.length > 0
+    ? orderedIds
+        .map((id) => displayItems.find((si) => si.id === id))
+        .filter((si): si is StapleItem => si !== null)
+    : displayItems;
+
+  const handleAddToTask = useCallback(
+    (item: StapleItem) => {
+      const title = buildTaskTitle(item);
+      onAddToTask({
+        title,
+        category_id: item.category_id,
+        note: item.note,
+      });
+      onRecordUsage(item.id);
+      toast.success(`「${item.name}」をリストに追加しました`);
+    },
+    [onAddToTask, onRecordUsage]
+  );
+
+  const handleLongPress = useCallback((item: StapleItem) => {
+    if (isEditMode) return;
+    setQuickAddItem(item);
+    setIsQuickAddOpen(true);
+  }, [isEditMode]);
+
+  const handleQuickAddConfirm = useCallback(
+    (item: StapleItem, overrideQuantity: number | null, overrideNote: string | null) => {
+      const quantity = overrideQuantity ?? item.default_quantity;
+      const note = overrideNote ?? item.note;
+      let title = item.name;
+      if (quantity !== null) {
+        const q = Number.isInteger(quantity) ? String(quantity) : String(quantity);
+        const unit = item.default_unit ?? "";
+        title = `${item.name} ${q}${unit}`.trim();
+      }
+      onAddToTask({ title, category_id: item.category_id, note });
+      onRecordUsage(item.id);
+      toast.success(`「${item.name}」をリストに追加しました`);
+    },
+    [onAddToTask, onRecordUsage]
+  );
+
+  const handleEditItem = useCallback((item: StapleItem) => {
+    setEditingItem(item);
+    setIsFormOpen(true);
+  }, []);
+
+  const handleFormSubmit = useCallback(
+    (data: {
+      name: string;
+      category_id: string | null;
+      default_quantity: number | null;
+      default_unit: string | null;
+      note: string | null;
+      icon: string | null;
+    }) => {
+      if (editingItem) {
+        onUpdateStapleItem(editingItem.id, data);
+      } else {
+        onAddStapleItem({ ...data, created_by: profileId });
+      }
+      setEditingItem(null);
+    },
+    [editingItem, onUpdateStapleItem, onAddStapleItem, profileId]
+  );
+
+  const handleDragEnd = useCallback(
+    (event: DragEndEvent) => {
+      const { active, over } = event;
+      if (!over || active.id === over.id) return;
+
+      const currentIds = orderedIds.length > 0 ? orderedIds : stapleItems.map((si) => si.id);
+      const oldIndex = currentIds.indexOf(String(active.id));
+      const newIndex = currentIds.indexOf(String(over.id));
+      if (oldIndex === -1 || newIndex === -1) return;
+
+      const newOrder = arrayMove(currentIds, oldIndex, newIndex);
+      setOrderedIds(newOrder);
+      onReorderStapleItems(newOrder);
+    },
+    [orderedIds, stapleItems, onReorderStapleItems]
+  );
+
+  const handleToggleEditMode = () => {
+    if (!isEditMode) {
+      setOrderedIds(stapleItems.map((si) => si.id));
+    }
+    setIsEditMode((v) => !v);
+  };
+
+  const handleClose = () => {
+    setIsEditMode(false);
+    setSearchQuery("");
+    onClose();
+  };
+
+  return (
+    <>
+      <BottomSheet isOpen={isOpen} onClose={handleClose}>
+        {/* カスタムヘッダー */}
+        <div className="-mx-4 -mt-2 mb-3 px-4">
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <ShoppingBag size={18} className="text-primary" />
+              <h2 className="text-lg font-bold text-foreground">定番品</h2>
+            </div>
+            <button
+              onClick={handleToggleEditMode}
+              className={`rounded-full px-3 py-1 text-sm font-medium transition-colors ${
+                isEditMode
+                  ? "bg-primary text-white"
+                  : "text-muted hover:text-foreground"
+              }`}
+            >
+              {isEditMode ? "完了" : "編集"}
+            </button>
+          </div>
+        </div>
+
+        {/* 検索 */}
+        {!isEditMode && (
+          <div className="mb-3 flex items-center gap-2 rounded-xl border border-border bg-surface px-3 py-2">
+            <Search size={16} className="text-muted shrink-0" />
+            <input
+              value={searchQuery}
+              onChange={(e) => setSearchQuery(e.target.value)}
+              placeholder="定番品を検索"
+              className="flex-1 bg-transparent text-sm text-foreground placeholder:text-subtle outline-none"
+            />
+          </div>
+        )}
+
+        {/* アイテムグリッド */}
+        {loading ? (
+          <div className="grid grid-cols-3 gap-3 pb-4">
+            {Array.from({ length: 6 }).map((_, i) => (
+              <div key={i} className="h-24 rounded-xl bg-surface-strong animate-pulse" />
+            ))}
+          </div>
+        ) : sortedItems.length === 0 ? (
+          <AnimatePresence>
+            <motion.div
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              className="flex flex-col items-center gap-3 py-12 text-center"
+            >
+              <span className="text-4xl">🛒</span>
+              <p className="text-sm font-medium text-foreground">
+                {searchQuery ? "見つかりませんでした" : "定番品がまだありません"}
+              </p>
+              {!searchQuery && (
+                <p className="text-xs text-muted">
+                  よく買うものを登録して、<br />ワンタップでリストに追加しましょう
+                </p>
+              )}
+              {!searchQuery && (
+                <button
+                  onClick={() => {
+                    setEditingItem(null);
+                    setIsFormOpen(true);
+                  }}
+                  className="mt-2 rounded-full bg-primary px-5 py-2 text-sm font-semibold text-white"
+                >
+                  最初の定番品を追加
+                </button>
+              )}
+            </motion.div>
+          </AnimatePresence>
+        ) : (
+          <DndContext
+            sensors={sensors}
+            collisionDetection={closestCenter}
+            onDragEnd={handleDragEnd}
+          >
+            <SortableContext
+              items={sortedItems.map((si) => si.id)}
+              strategy={rectSortingStrategy}
+            >
+              <div className="grid grid-cols-3 gap-3 pb-4">
+                {sortedItems.map((item) => (
+                  <SortableStapleCard
+                    key={item.id}
+                    item={item}
+                    categories={categories}
+                    isEditMode={isEditMode}
+                    onAddToTask={handleAddToTask}
+                    onLongPress={isEditMode ? handleEditItem : handleLongPress}
+                    onDelete={onDeleteStapleItem}
+                  />
+                ))}
+              </div>
+            </SortableContext>
+          </DndContext>
+        )}
+
+        {/* 追加ボタン */}
+        {!loading && (
+          <button
+            onClick={() => {
+              setEditingItem(null);
+              setIsFormOpen(true);
+            }}
+            className="flex w-full items-center justify-center gap-2 rounded-xl border border-dashed border-border py-3 text-sm font-medium text-muted hover:border-primary hover:text-primary transition-colors"
+          >
+            <Plus size={16} />
+            定番品を追加
+          </button>
+        )}
+      </BottomSheet>
+
+      {/* 定番品の作成・編集フォーム */}
+      <StapleItemFormSheet
+        isOpen={isFormOpen}
+        onClose={() => {
+          setIsFormOpen(false);
+          setEditingItem(null);
+        }}
+        categories={categories}
+        item={editingItem}
+        defaultCategoryId={selectedCategoryId}
+        onSubmit={handleFormSubmit}
+      />
+
+      {/* クイック追加（長押し） */}
+      <QuickAddSheet
+        isOpen={isQuickAddOpen}
+        item={quickAddItem}
+        onClose={() => {
+          setIsQuickAddOpen(false);
+          setQuickAddItem(null);
+        }}
+        onConfirm={handleQuickAddConfirm}
+      />
+    </>
+  );
+}

--- a/src/components/ui/bottom-sheet.tsx
+++ b/src/components/ui/bottom-sheet.tsx
@@ -8,9 +8,10 @@ interface BottomSheetProps {
   onClose: () => void;
   title?: string;
   children: React.ReactNode;
+  elevated?: boolean;
 }
 
-export function BottomSheet({ isOpen, onClose, title, children }: BottomSheetProps) {
+export function BottomSheet({ isOpen, onClose, title, children, elevated = false }: BottomSheetProps) {
   const [keyboardHeight, setKeyboardHeight] = useState(0);
   const [isTablet, setIsTablet] = useState(false);
 
@@ -65,7 +66,7 @@ export function BottomSheet({ isOpen, onClose, title, children }: BottomSheetPro
   return (
     <AnimatePresence>
       {isOpen && (
-        <div className="fixed inset-0 z-50 flex items-end md:items-center justify-center">
+        <div className={`fixed inset-0 flex items-end md:items-center justify-center ${elevated ? "z-[60]" : "z-50"}`}>
           <motion.div
             className="absolute inset-0 bg-black/40"
             initial={{ opacity: 0 }}

--- a/src/hooks/use-categories.test.ts
+++ b/src/hooks/use-categories.test.ts
@@ -32,6 +32,7 @@ describe("useCategories", () => {
     vi.clearAllMocks();
     chain = new MockQueryChain();
     mockClient = createMockSupabase(chain);
+    // @ts-expect-error - モックオブジェクトは SupabaseClient の全インターフェースを実装しない
     vi.mocked(createClient).mockReturnValue(mockClient as ReturnType<typeof createClient>);
   });
 

--- a/src/hooks/use-realtime-staple-items.ts
+++ b/src/hooks/use-realtime-staple-items.ts
@@ -1,0 +1,67 @@
+"use client";
+
+import { useEffect } from "react";
+import { createClient } from "@/lib/supabase/client";
+import type { StapleItem } from "@/types";
+
+export function useRealtimeStapleItems(
+  householdId: string | null,
+  setStapleItems: React.Dispatch<React.SetStateAction<StapleItem[]>>
+) {
+  useEffect(() => {
+    if (!householdId) return;
+
+    const supabase = createClient();
+    const channel = supabase
+      .channel(`staple_items:${householdId}`)
+      .on(
+        "postgres_changes",
+        {
+          event: "INSERT",
+          schema: "public",
+          table: "staple_items",
+          filter: `household_id=eq.${householdId}`,
+        },
+        (payload) => {
+          const newItem = payload.new as StapleItem;
+          setStapleItems((prev) => {
+            if (prev.some((si) => si.id === newItem.id)) return prev;
+            return [...prev, newItem];
+          });
+        }
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "UPDATE",
+          schema: "public",
+          table: "staple_items",
+          filter: `household_id=eq.${householdId}`,
+        },
+        (payload) => {
+          const updated = payload.new as StapleItem;
+          setStapleItems((prev) =>
+            prev.map((si) => (si.id === updated.id ? updated : si))
+          );
+        }
+      )
+      .on(
+        "postgres_changes",
+        {
+          event: "DELETE",
+          schema: "public",
+          table: "staple_items",
+          filter: `household_id=eq.${householdId}`,
+        },
+        (payload) => {
+          const deleted = payload.old as { id: string };
+          setStapleItems((prev) => prev.filter((si) => si.id !== deleted.id));
+        }
+      )
+      .subscribe();
+
+    return () => {
+      supabase.removeChannel(channel);
+    };
+  }, [householdId, setStapleItems]);
+}

--- a/src/hooks/use-staple-items.ts
+++ b/src/hooks/use-staple-items.ts
@@ -1,0 +1,167 @@
+"use client";
+
+import { useState, useEffect, useCallback, useMemo } from "react";
+import { toast } from "sonner";
+import { createClient } from "@/lib/supabase/client";
+import type { StapleItem } from "@/types";
+
+export function useStapleItems(householdId: string | null) {
+  const supabase = useMemo(() => createClient(), []);
+  const [stapleItems, setStapleItems] = useState<StapleItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchStapleItems = useCallback(async () => {
+    if (!householdId) return;
+    const { data, error } = await supabase
+      .from("staple_items")
+      .select("*")
+      .eq("household_id", householdId)
+      .order("sort_order")
+      .order("created_at", { ascending: true });
+
+    if (error) toast.error("定番品の取得に失敗しました");
+    if (data) setStapleItems(data);
+    setLoading(false);
+  }, [householdId, supabase]);
+
+  useEffect(() => {
+    fetchStapleItems();
+  }, [fetchStapleItems]);
+
+  const addStapleItem = async (item: {
+    name: string;
+    category_id?: string | null;
+    default_quantity?: number | null;
+    default_unit?: string | null;
+    note?: string | null;
+    icon?: string | null;
+    created_by?: string | null;
+  }) => {
+    if (!householdId) return;
+
+    const sortOrder = stapleItems.length;
+    const tempId = crypto.randomUUID();
+    const now = new Date().toISOString();
+    const optimisticItem: StapleItem = {
+      id: tempId,
+      household_id: householdId,
+      name: item.name,
+      category_id: item.category_id ?? null,
+      default_quantity: item.default_quantity ?? null,
+      default_unit: item.default_unit ?? null,
+      note: item.note ?? null,
+      icon: item.icon ?? null,
+      sort_order: sortOrder,
+      use_count: 0,
+      last_used_at: null,
+      created_by: item.created_by ?? null,
+      created_at: now,
+      updated_at: now,
+    };
+    setStapleItems((prev) => [...prev, optimisticItem]);
+
+    const { data, error } = await supabase
+      .from("staple_items")
+      .insert({ id: tempId, ...item, household_id: householdId, sort_order: sortOrder })
+      .select()
+      .single();
+
+    if (error) {
+      setStapleItems((prev) => prev.filter((si) => si.id !== tempId));
+      toast.error("定番品の追加に失敗しました");
+    } else if (data) {
+      setStapleItems((prev) => prev.map((si) => (si.id === tempId ? data : si)));
+    }
+    return { data, error };
+  };
+
+  const updateStapleItem = async (
+    id: string,
+    updates: Partial<
+      Pick<StapleItem, "name" | "category_id" | "default_quantity" | "default_unit" | "note" | "icon" | "sort_order">
+    >
+  ) => {
+    let snapshot = stapleItems;
+    setStapleItems((prev) => {
+      snapshot = prev;
+      return prev.map((si) => (si.id === id ? { ...si, ...updates } : si));
+    });
+
+    const { error } = await supabase.from("staple_items").update(updates).eq("id", id);
+
+    if (error) {
+      setStapleItems(snapshot);
+      toast.error("定番品の更新に失敗しました");
+    }
+    return { error };
+  };
+
+  const deleteStapleItem = async (id: string) => {
+    const previousItems = stapleItems;
+    setStapleItems((prev) => prev.filter((si) => si.id !== id));
+
+    const { error } = await supabase.from("staple_items").delete().eq("id", id);
+
+    if (error) {
+      setStapleItems(previousItems);
+      toast.error("定番品の削除に失敗しました");
+    }
+    return { error };
+  };
+
+  const reorderStapleItems = async (orderedIds: string[]) => {
+    let snapshot = stapleItems;
+    setStapleItems((prev) => {
+      snapshot = prev;
+      const idToItem = new Map(prev.map((si) => [si.id, si]));
+      return orderedIds
+        .map((id, i) => {
+          const item = idToItem.get(id);
+          if (!item) return null;
+          return { ...item, sort_order: i };
+        })
+        .filter((item): item is StapleItem => item !== null);
+    });
+
+    const { error } = await supabase.rpc("reorder_staple_items", {
+      p_item_ids: orderedIds,
+      p_sort_orders: orderedIds.map((_, i) => i),
+    });
+
+    if (error) {
+      setStapleItems(snapshot);
+      toast.error("定番品の並び替えに失敗しました");
+    }
+  };
+
+  const recordUsage = async (id: string) => {
+    const item = stapleItems.find((si) => si.id === id);
+    if (!item) return;
+
+    const now = new Date().toISOString();
+    const newCount = item.use_count + 1;
+
+    setStapleItems((prev) =>
+      prev.map((si) =>
+        si.id === id ? { ...si, use_count: newCount, last_used_at: now } : si
+      )
+    );
+
+    await supabase
+      .from("staple_items")
+      .update({ use_count: newCount, last_used_at: now })
+      .eq("id", id);
+  };
+
+  return {
+    stapleItems,
+    setStapleItems,
+    loading,
+    addStapleItem,
+    updateStapleItem,
+    deleteStapleItem,
+    reorderStapleItems,
+    recordUsage,
+    refetch: fetchStapleItems,
+  };
+}

--- a/src/hooks/use-tasks.test.ts
+++ b/src/hooks/use-tasks.test.ts
@@ -38,6 +38,7 @@ describe("useTasks", () => {
     vi.clearAllMocks();
     chain = new MockQueryChain();
     mockClient = createMockSupabase(chain);
+    // @ts-expect-error - モックオブジェクトは SupabaseClient の全インターフェースを実装しない
     vi.mocked(createClient).mockReturnValue(mockClient as ReturnType<typeof createClient>);
   });
 

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -318,6 +318,79 @@ export type Database = {
           },
         ];
       };
+      staple_items: {
+        Row: {
+          id: string;
+          household_id: string;
+          name: string;
+          category_id: string | null;
+          default_quantity: number | null;
+          default_unit: string | null;
+          note: string | null;
+          icon: string | null;
+          sort_order: number;
+          use_count: number;
+          last_used_at: string | null;
+          created_by: string | null;
+          created_at: string;
+          updated_at: string;
+        };
+        Insert: {
+          id?: string;
+          household_id: string;
+          name: string;
+          category_id?: string | null;
+          default_quantity?: number | null;
+          default_unit?: string | null;
+          note?: string | null;
+          icon?: string | null;
+          sort_order?: number;
+          use_count?: number;
+          last_used_at?: string | null;
+          created_by?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Update: {
+          id?: string;
+          household_id?: string;
+          name?: string;
+          category_id?: string | null;
+          default_quantity?: number | null;
+          default_unit?: string | null;
+          note?: string | null;
+          icon?: string | null;
+          sort_order?: number;
+          use_count?: number;
+          last_used_at?: string | null;
+          created_by?: string | null;
+          created_at?: string;
+          updated_at?: string;
+        };
+        Relationships: [
+          {
+            foreignKeyName: "staple_items_household_id_fkey";
+            columns: ["household_id"];
+            isOneToOne: false;
+            referencedRelation: "households";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "staple_items_category_id_fkey";
+            columns: ["category_id"];
+            isOneToOne: false;
+            referencedRelation: "categories";
+            referencedColumns: ["id"];
+          },
+          {
+            foreignKeyName: "staple_items_created_by_fkey";
+            columns: ["created_by"];
+            isOneToOne: false;
+            referencedRelation: "profiles";
+            referencedColumns: ["id"];
+          },
+        ];
+      };
     };
     Views: Record<string, never>;
     Functions: {
@@ -353,6 +426,10 @@ export type Database = {
       join_household_with_code: {
         Args: { p_code: string };
         Returns: string;
+      };
+      reorder_staple_items: {
+        Args: { p_item_ids: string[]; p_sort_orders: number[] };
+        Returns: undefined;
       };
     };
     Enums: Record<string, never>;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,6 +9,7 @@ export type Task = Tables["tasks"]["Row"];
 export type TaskAssignee = Tables["task_assignees"]["Row"];
 export type TaskImage = Tables["task_images"]["Row"];
 export type PushSubscription = Tables["push_subscriptions"]["Row"];
+export type StapleItem = Tables["staple_items"]["Row"];
 
 export type TaskWithAssignees = Task & {
   assignees: Profile[];

--- a/supabase/migrations/012_staple_items.sql
+++ b/supabase/migrations/012_staple_items.sql
@@ -1,0 +1,101 @@
+-- ============================================
+-- 012: 定番品(staple_items)テーブル追加
+-- ============================================
+-- 世帯ごとに「いつもの定番品」をマスタとして登録し、
+-- ワンタップで買い物リスト(tasks)に追加できる機能のDB基盤。
+-- RLS は supabase-rules.md の方針に従い get_my_household_id() 経由。
+-- ============================================
+
+-- テーブル作成
+create table public.staple_items (
+  id               uuid        primary key default gen_random_uuid(),
+  household_id     uuid        not null references public.households(id) on delete cascade,
+  name             text        not null,
+  category_id      uuid        references public.categories(id) on delete set null,
+  default_quantity numeric,
+  default_unit     text,
+  note             text,
+  icon             text,
+  sort_order       integer     not null default 0,
+  use_count        integer     not null default 0,
+  last_used_at     timestamptz,
+  created_by       uuid        references auth.users(id),
+  created_at       timestamptz not null default now(),
+  updated_at       timestamptz not null default now()
+);
+
+-- インデックス
+create index idx_staple_items_household
+  on public.staple_items(household_id);
+
+create index idx_staple_items_usage
+  on public.staple_items(household_id, use_count desc, last_used_at desc nulls last);
+
+-- updated_at 自動更新トリガー（handle_updated_at は 001 で定義済み）
+create trigger handle_staple_items_updated_at
+  before update on public.staple_items
+  for each row execute function public.handle_updated_at();
+
+-- RLS
+alter table public.staple_items enable row level security;
+
+create policy "staple_items_select"
+  on public.staple_items for select
+  using (household_id = public.get_my_household_id());
+
+create policy "staple_items_insert"
+  on public.staple_items for insert
+  with check (household_id = public.get_my_household_id());
+
+create policy "staple_items_update"
+  on public.staple_items for update
+  using  (household_id = public.get_my_household_id())
+  with check (household_id = public.get_my_household_id());
+
+create policy "staple_items_delete"
+  on public.staple_items for delete
+  using (household_id = public.get_my_household_id());
+
+-- Realtime 購読対象に追加
+alter publication supabase_realtime add table public.staple_items;
+
+-- 並び順一括更新 RPC（reorder_tasks と同パターン）
+create or replace function public.reorder_staple_items(
+  p_item_ids   uuid[],
+  p_sort_orders integer[]
+)
+returns void
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_household_id uuid;
+begin
+  v_household_id := public.get_my_household_id();
+  if v_household_id is null then
+    raise exception 'Authentication required';
+  end if;
+
+  if array_length(p_item_ids, 1) is null then
+    return;
+  end if;
+
+  -- 全アイテムが自世帯に属することを検証
+  if exists (
+    select 1 from unnest(p_item_ids) as item_id
+    where not exists (
+      select 1 from public.staple_items si
+      where si.id = item_id and si.household_id = v_household_id
+    )
+  ) then
+    raise exception 'Item does not belong to your household';
+  end if;
+
+  for i in 1..array_length(p_item_ids, 1) loop
+    update public.staple_items
+    set sort_order = p_sort_orders[i]
+    where id = p_item_ids[i] and household_id = v_household_id;
+  end loop;
+end;
+$$;


### PR DESCRIPTION
世帯ごとに「いつもの定番品」をマスタ登録し、ワンタップで
買い物リストへ追加できる機能を実装。

- supabase/migrations/012_staple_items.sql: staple_items テーブル、
  RLS ポリシー（get_my_household_id() 経由）、インデックス、
  updated_at トリガー、Realtime 購読、reorder_staple_items RPC を追加
- src/types/database.ts: staple_items の Row/Insert/Update 型と
  reorder_staple_items 関数型を追加
- src/hooks/use-staple-items.ts: CRUD + 楽観的更新 + recordUsage フック
- src/hooks/use-realtime-staple-items.ts: Realtime 購読フック
- src/components/staple/staple-item-card.tsx: タップ即追加・長押しで
  調整シート・編集モード時にジグル＋削除ボタンを表示するカード
- src/components/staple/staple-item-form-sheet.tsx: 定番品の作成・編集フォーム
  （アイコン絵文字プリセット・カテゴリ・数量・単位・メモ）
- src/components/staple/staple-items-sheet.tsx: グリッド表示・検索・
  編集モード・DnD 並び替え・クイック追加シートを統合したメインシート
- src/components/ui/bottom-sheet.tsx: elevated prop を追加（z-[60] で重なり対応）
- src/app/page.tsx: 定番品ボタン（FAB 横）と StapleItemsSheet を統合

https://claude.ai/code/session_01NCruAF5M6fdLj4ajtAwCG8