### PR TITLE
fix: db reset 時のシード失敗を修正

### DIFF
--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -70,7 +70,14 @@ VALUES (
 ) ON CONFLICT DO NOTHING;
 
 -- 3. デフォルトカテゴリを作成
-SELECT create_default_categories('b0000000-0000-0000-0000-000000000001'::uuid);
+-- create_default_categories() は auth.uid() チェックがあり未認証シードから呼べないため直接 INSERT する
+INSERT INTO public.categories (household_id, name, color, icon, sort_order) VALUES
+  ('b0000000-0000-0000-0000-000000000001'::uuid, '買い物', '#ef4444', 'shopping-cart', 0),
+  ('b0000000-0000-0000-0000-000000000001'::uuid, '料理',   '#f97316', 'chef-hat',      1),
+  ('b0000000-0000-0000-0000-000000000001'::uuid, '掃除',   '#22c55e', 'sparkles',      2),
+  ('b0000000-0000-0000-0000-000000000001'::uuid, '洗濯',   '#3b82f6', 'shirt',         3),
+  ('b0000000-0000-0000-0000-000000000001'::uuid, 'その他', '#6366f1', 'list',          4)
+ON CONFLICT DO NOTHING;
 
 -- 4. トリガーで作成されたプロフィールを世帯に紐付け
 UPDATE public.profiles


### PR DESCRIPTION
## 変更内容

`npx supabase db reset` が `Authentication required (SQLSTATE P0001)` で失敗する問題を修正。

## 原因

`011_restore_rpc_auth_checks.sql` で `create_default_categories()` に `auth.uid() is null` チェックが追加されたが、`db reset` のシード実行は未認証セッションのため関数がエラーを投げていた。

## 修正

`seed.sql` の `create_default_categories()` 呼び出しを、同内容の直接 `INSERT` に置き換えた。

## 動作確認

```
npx supabase db reset
→ Finished supabase db reset on branch main.
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)