### PR TITLE
fix: 定番品グリッドのカード高さ不揃いを修正

### DIFF
--- a/src/components/staple/staple-item-card.tsx
+++ b/src/components/staple/staple-item-card.tsx
@@ -62,7 +62,7 @@ export function StapleItemCard({
 
   return (
     <motion.div
-      className="relative"
+      className="relative h-full"
       animate={
         isEditMode
           ? { rotate: [-1, 1, -1, 1, 0] }
@@ -92,7 +92,7 @@ export function StapleItemCard({
         onClick={isEditMode ? () => onLongPress(item) : undefined}
         disabled={isDragging}
         className={[
-          "flex w-full flex-col items-center gap-1.5 rounded-xl border px-2 py-3 text-center transition-colors",
+          "flex w-full h-full flex-col items-center gap-1.5 rounded-xl border px-2 py-3 text-center transition-colors",
           "bg-surface border-border active:bg-surface-strong",
           isEditMode ? "cursor-default" : "cursor-pointer",
           isDragging ? "opacity-50 shadow-lg" : "",

--- a/src/components/staple/staple-items-sheet.tsx
+++ b/src/components/staple/staple-items-sheet.tsx
@@ -45,7 +45,7 @@ function SortableStapleCard(props: SortableStapleCardProps) {
   };
 
   return (
-    <div ref={setNodeRef} style={style} {...(props.isEditMode ? { ...attributes, ...listeners } : {})}>
+    <div ref={setNodeRef} style={style} className="h-full" {...(props.isEditMode ? { ...attributes, ...listeners } : {})}>
       <StapleItemCard {...props} isDragging={isDragging} />
     </div>
   );


### PR DESCRIPTION
グリッドアイテム内の motion.div と button に h-full がなく、
use_count バッジの有無でカード高さがズレていた。