### PR TITLE
fix: 定番品シートのヘッダー文字が見切れる問題を修正

### DIFF
--- a/src/components/staple/staple-items-sheet.tsx
+++ b/src/components/staple/staple-items-sheet.tsx
@@ -294,7 +294,7 @@ export function StapleItemsSheet({
     <>
       <BottomSheet isOpen={isOpen} onClose={handleClose}>
         {/* カスタムヘッダー */}
-        <div className="-mx-4 -mt-2 mb-3 px-4">
+        <div className="mb-3">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-2">
               <ShoppingBag size={18} className="text-primary" />


### PR DESCRIPTION
カスタムヘッダーに付けていた -mt-2 が、BottomSheet 側の sticky
ドラッグハンドル領域 (z-10 / 不透明 bg-surface) に食い込み、
「定番品」テキストの上端が背景に覆われて見切れていた。
背景拡張用途で意味を持たない -mx-4 px-4 と併せて除去し、
ヘッダーが sticky 領域の下に自然に並ぶようにする。