### PR TITLE
fix: profile.household_id の直接書き換えによる世帯横移動を防止

### DIFF
--- a/src/components/household/create-form.tsx
+++ b/src/components/household/create-form.tsx
@@ -16,50 +16,17 @@ export function CreateHouseholdForm() {
     setLoading(true);
 
     const supabase = createClient();
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
 
-    if (!user) {
-      setError("ログインが必要です");
-      setLoading(false);
-      return;
-    }
+    const { data: householdId, error: rpcError } = await supabase.rpc(
+      "create_household_with_defaults",
+      { p_name: name }
+    );
 
-    // Create household
-    const { data: household, error: hError } = await supabase
-      .from("households")
-      .insert({ name: name || "わが家" })
-      .select()
-      .single();
-
-    if (hError || !household) {
+    if (rpcError || !householdId) {
       setError("ハウスホールドの作成に失敗しました");
       setLoading(false);
       return;
     }
-
-    // Link profile to household
-    const { error: pError } = await supabase
-      .from("profiles")
-      .update({ household_id: household.id })
-      .eq("id", user.id);
-
-    if (pError) {
-      setError("プロフィールの更新に失敗しました");
-      setLoading(false);
-      return;
-    }
-
-    // Create default categories
-    await supabase.rpc("create_default_categories", {
-      p_household_id: household.id,
-    });
-
-    // Generate invite code
-    await supabase.rpc("generate_invite_code", {
-      p_household_id: household.id,
-    });
 
     router.push("/");
     router.refresh();

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -431,6 +431,10 @@ export type Database = {
         Args: { p_item_ids: string[]; p_sort_orders: number[] };
         Returns: undefined;
       };
+      create_household_with_defaults: {
+        Args: { p_name: string };
+        Returns: string;
+      };
     };
     Enums: Record<string, never>;
     CompositeTypes: Record<string, never>;

--- a/supabase/migrations/013_lock_profile_household_update.sql
+++ b/supabase/migrations/013_lock_profile_household_update.sql
@@ -1,0 +1,90 @@
+-- ============================================
+-- 013: profile.household_id の直接書き換えを禁止
+-- ============================================
+-- 既存の profiles UPDATE ポリシーは USING のみで WITH CHECK が無いため、
+-- 認証ユーザーが自分の profile に対して任意の household_id を書き込めた。
+-- 結果として、別世帯の UUID を知っているユーザーは
+--   update profiles set household_id = '<target>' where id = auth.uid()
+-- だけで標的世帯のメンバーになりすまし、tasks / categories などに
+-- フルアクセスできてしまう状態だった（011 のコメントで認識済み）。
+--
+-- 本マイグレーションでは：
+--   1. profiles UPDATE ポリシーに WITH CHECK を追加し、household_id を
+--      自分の現在値から変更する UPDATE を弾く。
+--   2. 世帯参加は既存の join_household_with_code RPC のみで可能にする。
+--   3. 新規世帯作成は create_household_with_defaults RPC（新設）で
+--      households 作成・profile 紐付け・デフォルトカテゴリ・招待コードを
+--      atomic に行う（SECURITY DEFINER で RLS をバイパス）。
+-- ============================================
+
+
+-- ============================================
+-- Step 1: profiles UPDATE ポリシーを差し替え
+-- ============================================
+drop policy if exists "Users can update own profile" on public.profiles;
+
+create policy "Users can update own profile"
+  on public.profiles for update
+  using (auth.uid() = id)
+  with check (
+    auth.uid() = id
+    and household_id is not distinct from (
+      select p.household_id from public.profiles p where p.id = auth.uid()
+    )
+  );
+
+
+-- ============================================
+-- Step 2: 世帯作成 + 初期化を atomic に行う RPC
+-- ============================================
+create or replace function public.create_household_with_defaults(p_name text)
+returns uuid
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_household_id uuid;
+  v_existing_household uuid;
+  v_code text;
+  v_name text;
+begin
+  if auth.uid() is null then
+    raise exception 'Authentication required';
+  end if;
+
+  -- 既に世帯所属の場合は二重作成を拒否
+  select household_id into v_existing_household
+  from public.profiles where id = auth.uid();
+
+  if v_existing_household is not null then
+    raise exception 'Already a member of a household';
+  end if;
+
+  -- 世帯名を正規化（空文字 → 'わが家'、長さ制限は households_name_length に委譲）
+  v_name := coalesce(nullif(trim(p_name), ''), 'わが家');
+
+  insert into public.households(name)
+  values (v_name)
+  returning id into v_household_id;
+
+  update public.profiles
+  set household_id = v_household_id
+  where id = auth.uid();
+
+  insert into public.categories (household_id, name, color, icon, sort_order) values
+    (v_household_id, '買い物', '#ef4444', 'shopping-cart', 0),
+    (v_household_id, '料理', '#f97316', 'chef-hat', 1),
+    (v_household_id, '掃除', '#22c55e', 'sparkles', 2),
+    (v_household_id, '洗濯', '#3b82f6', 'shirt', 3),
+    (v_household_id, 'その他', '#6366f1', 'list', 4);
+
+  v_code := upper(encode(gen_random_bytes(8), 'hex'));
+  update public.households
+  set invite_code = v_code,
+      invite_code_expires_at = now() + interval '24 hours'
+  where id = v_household_id;
+
+  return v_household_id;
+end;
+$$;


### PR DESCRIPTION
profiles UPDATE RLS ポリシーに WITH CHECK が無く、認証済みユーザーが
自分の profile.household_id を任意の世帯 UUID に書き換えることで
標的世帯の tasks/categories/メンバー情報へフルアクセスできた問題を修正。

- migration 013: profiles UPDATE に WITH CHECK を追加し household_id 不変を強制
- create_household_with_defaults RPC を新設し、世帯作成・初期カテゴリ・
  招待コード生成を SECURITY DEFINER で atomic に実行
- create-form.tsx を新 RPC 1 回呼びに置き換え（直接 profiles.update を撤去）

世帯参加は既存の join_household_with_code RPC、新規作成は本 RPC のみが
profiles.household_id を変更可能な経路となり、クライアントからの直接書き換えは
RLS で拒否される。