### PR TITLE
perf: 起動時のデータ取得と認証往復を削減

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { useRouter } from "next/navigation";
+import dynamic from "next/dynamic";
 import { Settings, ArrowUpDown, Check, BookMarked } from "lucide-react";
 import { motion } from "framer-motion";
 import { toast } from "sonner";
@@ -9,18 +10,29 @@ import { createClient } from "@/lib/supabase/client";
 import { CategoryTabs } from "@/components/category/category-tabs";
 import { TaskList } from "@/components/task/task-list";
 import { TaskListSkeleton } from "@/components/task/task-list-skeleton";
-import { TaskCreateSheet } from "@/components/task/task-create-sheet";
-import { TaskDetailModal } from "@/components/task/task-detail-modal";
 import { SwipeableTaskContainer } from "@/components/task/swipeable-task-container";
 import { Fab } from "@/components/ui/fab";
 import { Avatar } from "@/components/ui/avatar";
 import { RecommendationSection } from "@/components/recommendation/recommendation-section";
+
+// 初期表示に不要な重いシート/モーダルは初回オープン時に遅延ロードする（起動バンドル削減）
+const TaskCreateSheet = dynamic(
+  () => import("@/components/task/task-create-sheet").then((m) => m.TaskCreateSheet),
+  { ssr: false }
+);
+const TaskDetailModal = dynamic(
+  () => import("@/components/task/task-detail-modal").then((m) => m.TaskDetailModal),
+  { ssr: false }
+);
+const StapleItemsSheet = dynamic(
+  () => import("@/components/staple/staple-items-sheet").then((m) => m.StapleItemsSheet),
+  { ssr: false }
+);
 import { useTasks } from "@/hooks/use-tasks";
 import { useCategories } from "@/hooks/use-categories";
 import { useRealtimeTasks } from "@/hooks/use-realtime-tasks";
 import { useSort, SORT_OPTIONS } from "@/hooks/use-sort";
 import { BottomSheet } from "@/components/ui/bottom-sheet";
-import { StapleItemsSheet } from "@/components/staple/staple-items-sheet";
 import { useTaskRecommendations } from "@/hooks/use-task-recommendations";
 import { useTitleSuggestions } from "@/hooks/use-title-suggestions";
 import { usePageData } from "@/hooks/use-page-data";
@@ -38,6 +50,10 @@ export default function Home() {
   const [isStapleOpen, setIsStapleOpen] = useState(false);
   const [selectedTask, setSelectedTask] = useState<Task | null>(null);
   const [isSortOpen, setIsSortOpen] = useState(false);
+  // 遅延ロードしたシート/モーダルは初回オープン後はマウントを維持し、閉じるアニメを保つ
+  const [isCreateMounted, setIsCreateMounted] = useState(false);
+  const [isStapleMounted, setIsStapleMounted] = useState(false);
+  const [isDetailMounted, setIsDetailMounted] = useState(false);
   const { sortOption, setSortOption } = useSort();
 
   const SORT_SHORT_LABELS: Record<string, string> = {
@@ -121,7 +137,18 @@ export default function Home() {
   }, [allTasks, selectedCategoryId, sortOption]);
 
   const handleToggle = useCallback(async (id: string) => { await toggleTask(id); refetchRecommendations(); }, [toggleTask, refetchRecommendations]);
-  const handleTap = useCallback((task: Task) => setSelectedTask(task), []);
+  const handleTap = useCallback((task: Task) => {
+    setIsDetailMounted(true);
+    setSelectedTask(task);
+  }, []);
+  const handleOpenCreate = useCallback(() => {
+    setIsCreateMounted(true);
+    setIsCreateOpen(true);
+  }, []);
+  const handleOpenStaple = useCallback(() => {
+    setIsStapleMounted(true);
+    setIsStapleOpen(true);
+  }, []);
   const handleDeleteTask = useCallback(async (id: string) => { await deleteTask(id); refetchRecommendations(); }, [deleteTask, refetchRecommendations]);
   const handleCloseCreate = useCallback(() => setIsCreateOpen(false), []);
   const handleSubmit = useCallback(async (task: { title: string; category_id?: string | null; due_date?: string | null; memo?: string | null; url?: string | null }) => {
@@ -279,7 +306,7 @@ export default function Home() {
 
       {/* 定番品ボタン */}
       <motion.button
-        onClick={() => setIsStapleOpen(true)}
+        onClick={handleOpenStaple}
         initial={{ y: 64, opacity: 0 }}
         animate={{ y: 0, opacity: 1 }}
         whileHover={{ scale: 1.1 }}
@@ -292,45 +319,51 @@ export default function Home() {
       </motion.button>
 
       {/* FAB */}
-      <Fab onClick={() => setIsCreateOpen(true)} />
+      <Fab onClick={handleOpenCreate} />
 
       {/* Create Sheet */}
-      <TaskCreateSheet
-        isOpen={isCreateOpen}
-        onClose={handleCloseCreate}
-        categories={categories}
-        selectedCategoryId={selectedCategoryId}
-        getSuggestions={getSuggestions}
-        onSubmit={handleSubmit}
-      />
+      {isCreateMounted && (
+        <TaskCreateSheet
+          isOpen={isCreateOpen}
+          onClose={handleCloseCreate}
+          categories={categories}
+          selectedCategoryId={selectedCategoryId}
+          getSuggestions={getSuggestions}
+          onSubmit={handleSubmit}
+        />
+      )}
 
       {/* Detail Modal */}
-      <TaskDetailModal
-        task={selectedTask}
-        isOpen={!!selectedTask}
-        onClose={handleCloseDetail}
-        categories={categories}
-        members={members}
-        onUpdate={handleUpdate}
-        onDelete={handleDeleteTask}
-      />
+      {isDetailMounted && (
+        <TaskDetailModal
+          task={selectedTask}
+          isOpen={!!selectedTask}
+          onClose={handleCloseDetail}
+          categories={categories}
+          members={members}
+          onUpdate={handleUpdate}
+          onDelete={handleDeleteTask}
+        />
+      )}
 
       {/* Staple Items Sheet */}
-      <StapleItemsSheet
-        isOpen={isStapleOpen}
-        onClose={() => setIsStapleOpen(false)}
-        stapleItems={stapleItems}
-        loading={stapleLoading}
-        categories={categories}
-        selectedCategoryId={selectedCategoryId}
-        profileId={profile?.id ?? null}
-        onAddToTask={(task) => addTask({ ...task, created_by: profile?.id ?? null })}
-        onAddStapleItem={addStapleItem}
-        onUpdateStapleItem={updateStapleItem}
-        onDeleteStapleItem={deleteStapleItem}
-        onReorderStapleItems={reorderStapleItems}
-        onRecordUsage={recordUsage}
-      />
+      {isStapleMounted && (
+        <StapleItemsSheet
+          isOpen={isStapleOpen}
+          onClose={() => setIsStapleOpen(false)}
+          stapleItems={stapleItems}
+          loading={stapleLoading}
+          categories={categories}
+          selectedCategoryId={selectedCategoryId}
+          profileId={profile?.id ?? null}
+          onAddToTask={(task) => addTask({ ...task, created_by: profile?.id ?? null })}
+          onAddStapleItem={addStapleItem}
+          onUpdateStapleItem={updateStapleItem}
+          onDeleteStapleItem={deleteStapleItem}
+          onReorderStapleItems={reorderStapleItems}
+          onRecordUsage={recordUsage}
+        />
+      )}
 
       {/* Sort Sheet */}
       <BottomSheet isOpen={isSortOpen} onClose={() => setIsSortOpen(false)} title="並び替え">

--- a/src/hooks/use-page-data.ts
+++ b/src/hooks/use-page-data.ts
@@ -33,9 +33,12 @@ export function usePageData(options: UsePageDataOptions = {}): PageData {
   useEffect(() => {
     const load = async () => {
       const supabase = createClient();
+      // middleware が全リクエストでサーバ側セッション検証を済ませているため、
+      // ここはネットワーク往復のない getSession() で十分（認証往復の二重化を回避）
       const {
-        data: { user },
-      } = await supabase.auth.getUser();
+        data: { session },
+      } = await supabase.auth.getSession();
+      const user = session?.user;
 
       if (!user) {
         router.push("/login");

--- a/src/hooks/use-task-recommendations.ts
+++ b/src/hooks/use-task-recommendations.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo } from "react";
 import { createClient } from "@/lib/supabase/client";
+import { runWhenIdle } from "@/lib/idle";
 import type { TaskRecommendation } from "@/types";
 
 export function useTaskRecommendations(householdId: string | null, profileId?: string | null) {
@@ -19,9 +20,11 @@ export function useTaskRecommendations(householdId: string | null, profileId?: s
     setLoading(false);
   }, [householdId, supabase]);
 
+  // 完了タスク全走査で重い RPC のため、起動クリティカルパスから外してアイドル時に実行
   useEffect(() => {
-    fetchRecommendations();
-  }, [fetchRecommendations]);
+    if (!householdId) return;
+    return runWhenIdle(() => fetchRecommendations());
+  }, [householdId, fetchRecommendations]);
 
   const dismiss = useCallback(
     async (normalizedTitle: string, medianDays: number) => {

--- a/src/hooks/use-tasks.test.ts
+++ b/src/hooks/use-tasks.test.ts
@@ -62,6 +62,16 @@ describe("useTasks", () => {
       expect(chain.order).toHaveBeenNthCalledWith(2, "sort_order");
       expect(chain.order).toHaveBeenNthCalledWith(3, "created_at", { ascending: false });
     });
+
+    it("完了済みは直近のみ: 未完了 OR 直近完了に絞る or フィルタを呼ぶ", async () => {
+      chain._result = { data: [], error: null };
+      renderHook(() => useTasks(HOUSEHOLD_ID));
+
+      await waitFor(() => expect(chain.or).toHaveBeenCalled());
+      expect(chain.or).toHaveBeenCalledWith(
+        expect.stringMatching(/^is_done\.eq\.false,completed_at\.gte\./)
+      );
+    });
   });
 
   describe("addTask", () => {

--- a/src/hooks/use-tasks.ts
+++ b/src/hooks/use-tasks.ts
@@ -6,6 +6,9 @@ import { createClient } from "@/lib/supabase/client";
 import { sendPushNotification } from "@/lib/push";
 import type { Task } from "@/types";
 
+// 未完了タスクは全件、完了済みはこの日数以内のものだけ初期ロードする（蓄積による起動遅延を防ぐ）
+const COMPLETED_TASKS_WINDOW_DAYS = 30;
+
 export function useTasks(householdId: string | null) {
   const supabase = useMemo(() => createClient(), []);
   const [tasks, setTasks] = useState<Task[]>([]);
@@ -14,10 +17,15 @@ export function useTasks(householdId: string | null) {
   const fetchTasks = useCallback(async () => {
     if (!householdId) return;
 
+    const completedCutoff = new Date(
+      Date.now() - COMPLETED_TASKS_WINDOW_DAYS * 24 * 60 * 60 * 1000
+    ).toISOString();
+
     const { data, error } = await supabase
       .from("tasks")
       .select("*")
       .eq("household_id", householdId)
+      .or(`is_done.eq.false,completed_at.gte.${completedCutoff}`)
       .order("is_done")
       .order("sort_order")
       .order("created_at", { ascending: false });

--- a/src/hooks/use-title-suggestions.ts
+++ b/src/hooks/use-title-suggestions.ts
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useMemo, useCallback } from "react";
 import { createClient } from "@/lib/supabase/client";
+import { runWhenIdle } from "@/lib/idle";
 
 type PastTask = { title: string; category_id: string | null };
 
@@ -12,31 +13,34 @@ export function useTitleSuggestions(householdId: string | null) {
   const supabase = useMemo(() => createClient(), []);
   const [pastTasks, setPastTasks] = useState<PastTask[]>([]);
 
+  // 作成シートを開くまで不要な500件取得のため、起動クリティカルパスから外してアイドル時に実行
   useEffect(() => {
     if (!householdId) return;
 
-    (async () => {
-      const { data } = await supabase
-        .from("tasks")
-        .select("title, category_id")
-        .eq("household_id", householdId)
-        .order("created_at", { ascending: false })
-        .limit(500);
+    return runWhenIdle(() => {
+      (async () => {
+        const { data } = await supabase
+          .from("tasks")
+          .select("title, category_id")
+          .eq("household_id", householdId)
+          .order("created_at", { ascending: false })
+          .limit(500);
 
-      if (data) {
-        // 重複を除去し、最新の表記を優先（最初に出現したものを残す）
-        const seen = new Set<string>();
-        const unique: PastTask[] = [];
-        for (const row of data) {
-          const lower = row.title.toLowerCase();
-          if (!seen.has(lower)) {
-            seen.add(lower);
-            unique.push({ title: row.title, category_id: row.category_id });
+        if (data) {
+          // 重複を除去し、最新の表記を優先（最初に出現したものを残す）
+          const seen = new Set<string>();
+          const unique: PastTask[] = [];
+          for (const row of data) {
+            const lower = row.title.toLowerCase();
+            if (!seen.has(lower)) {
+              seen.add(lower);
+              unique.push({ title: row.title, category_id: row.category_id });
+            }
           }
+          setPastTasks(unique);
         }
-        setPastTasks(unique);
-      }
-    })();
+      })();
+    });
   }, [householdId, supabase]);
 
   const getSuggestions = useCallback(

--- a/src/lib/idle.ts
+++ b/src/lib/idle.ts
@@ -1,0 +1,16 @@
+/**
+ * ブラウザがアイドルになってからコールバックを実行する。
+ * requestIdleCallback 非対応環境では setTimeout にフォールバックする。
+ * 返り値の関数を呼ぶとスケジュールをキャンセルできる（実行前のみ有効）。
+ */
+export function runWhenIdle(callback: () => void): () => void {
+  if (
+    typeof window !== "undefined" &&
+    typeof window.requestIdleCallback === "function"
+  ) {
+    const handle = window.requestIdleCallback(callback);
+    return () => window.cancelIdleCallback(handle);
+  }
+  const timer = setTimeout(callback, 200);
+  return () => clearTimeout(timer);
+}

--- a/src/test/mocks/supabase.ts
+++ b/src/test/mocks/supabase.ts
@@ -14,7 +14,9 @@ export class MockQueryChain {
   update = vi.fn().mockReturnThis();
   delete = vi.fn().mockReturnThis();
   eq = vi.fn().mockReturnThis();
+  or = vi.fn().mockReturnThis();
   order = vi.fn().mockReturnThis();
+  limit = vi.fn().mockReturnThis();
   single = vi.fn().mockResolvedValue({ data: null, error: null });
 
   // Thenable interface — `await chain` でここが呼ばれる


### PR DESCRIPTION
数ヶ月の利用で完了タスクが蓄積し起動が遅くなる問題に対応。
- 完了済みタスクは直近30日分のみ初期ロード（未完了は全件取得）
- usePageData の認証を getUser から getSession に変更し往復を削減
  （middleware がサーバ側で検証済みのため安全）
- 重いレコメンド RPC と500件のタイトルサジェスト取得をアイドル時実行に遅延
- 作成/詳細/定番品シートを next/dynamic で初回オープン時に遅延ロード

https://claude.ai/code/session_01MvUqZXKjawer8fu2g998Co