### PR TITLE
perf: React Query 導入でページ遷移時の再取得を排除

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "@dnd-kit/utilities": "^3.2.2",
         "@supabase/ssr": "^0.8.0",
         "@supabase/supabase-js": "^2.95.3",
+        "@tanstack/react-query": "^5.100.14",
         "@types/canvas-confetti": "^1.9.0",
         "canvas-confetti": "^1.9.4",
         "framer-motion": "^12.34.0",
@@ -2535,6 +2536,32 @@
         "@tailwindcss/oxide": "4.1.18",
         "postcss": "^8.4.41",
         "tailwindcss": "4.1.18"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.14.tgz",
+      "integrity": "sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.14.tgz",
+      "integrity": "sha512-oOr6aRdSFEwWhzxEkD/9ZcItM3+LjBSkeVmadWKwUssAHTsqd/7bOjWrX4AbvEkoEhgAxzN0Xk6H/aYzXiYBAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@testing-library/dom": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@dnd-kit/utilities": "^3.2.2",
     "@supabase/ssr": "^0.8.0",
     "@supabase/supabase-js": "^2.95.3",
+    "@tanstack/react-query": "^5.100.14",
     "@types/canvas-confetti": "^1.9.0",
     "canvas-confetti": "^1.9.4",
     "framer-motion": "^12.34.0",

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata, Viewport } from "next";
 import { Inter, Geist_Mono } from "next/font/google";
 import { ServiceWorkerRegister } from "@/components/ServiceWorkerRegister";
 import { Toaster } from "@/components/ui/toaster";
+import { Providers } from "@/app/providers";
 import "./globals.css";
 
 const inter = Inter({
@@ -56,7 +57,7 @@ export default function RootLayout({
       >
         <ServiceWorkerRegister />
         <Toaster />
-        {children}
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/src/app/providers.tsx
+++ b/src/app/providers.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useState } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+export function Providers({ children }: { children: React.ReactNode }) {
+  // リクエスト/レンダ間で QueryClient を共有しないよう、初回マウント時に一度だけ生成する
+  const [queryClient] = useState(
+    () =>
+      new QueryClient({
+        defaultOptions: {
+          queries: {
+            // 遷移直後はキャッシュを即時表示し、この時間を過ぎていれば裏で再検証する
+            staleTime: 30_000,
+            gcTime: 5 * 60_000,
+            refetchOnWindowFocus: true,
+            retry: 1,
+          },
+        },
+      })
+  );
+
+  return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+}

--- a/src/hooks/use-categories.test.ts
+++ b/src/hooks/use-categories.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { useCategories } from "@/hooks/use-categories";
 import { createClient } from "@/lib/supabase/client";
 import { MockQueryChain, createMockSupabase } from "@/test/mocks/supabase";
+import { createQueryWrapper } from "@/test/query-wrapper";
 import type { Category } from "@/types";
 
 vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
@@ -41,7 +42,7 @@ describe("useCategories", () => {
       const existing = [makeCategory({ sort_order: 0 }), makeCategory({ sort_order: 1 })];
       chain._result = { data: existing, error: null };
 
-      const { result } = renderHook(() => useCategories(HOUSEHOLD_ID));
+      const { result } = renderHook(() => useCategories(HOUSEHOLD_ID), { wrapper: createQueryWrapper() });
       await waitFor(() => expect(result.current.categories).toHaveLength(2));
 
       const newCat = makeCategory({ name: "新カテゴリ", sort_order: 2 });
@@ -54,7 +55,7 @@ describe("useCategories", () => {
       expect(chain.insert).toHaveBeenCalledWith(
         expect.objectContaining({ sort_order: 2 })
       );
-      expect(result.current.categories).toHaveLength(3);
+      await waitFor(() => expect(result.current.categories).toHaveLength(3));
     });
   });
 
@@ -63,14 +64,14 @@ describe("useCategories", () => {
       const cat = makeCategory({ id: "c-1" });
       chain._result = { data: [cat], error: null };
 
-      const { result } = renderHook(() => useCategories(HOUSEHOLD_ID));
+      const { result } = renderHook(() => useCategories(HOUSEHOLD_ID), { wrapper: createQueryWrapper() });
       await waitFor(() => expect(result.current.categories).toHaveLength(1));
 
       await act(async () => {
         await result.current.deleteCategory("c-1");
       });
 
-      expect(result.current.categories).toHaveLength(0);
+      await waitFor(() => expect(result.current.categories).toHaveLength(0));
     });
   });
 
@@ -79,14 +80,14 @@ describe("useCategories", () => {
       const cat = makeCategory({ id: "c-1", name: "旧名前", color: "#0000ff" });
       chain._result = { data: [cat], error: null };
 
-      const { result } = renderHook(() => useCategories(HOUSEHOLD_ID));
+      const { result } = renderHook(() => useCategories(HOUSEHOLD_ID), { wrapper: createQueryWrapper() });
       await waitFor(() => expect(result.current.categories).toHaveLength(1));
 
       await act(async () => {
         await result.current.updateCategory("c-1", { name: "新名前" });
       });
 
-      expect(result.current.categories[0].name).toBe("新名前");
+      await waitFor(() => expect(result.current.categories[0].name).toBe("新名前"));
       expect(result.current.categories[0].color).toBe("#0000ff");
     });
   });

--- a/src/hooks/use-categories.ts
+++ b/src/hooks/use-categories.ts
@@ -1,31 +1,52 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useEffect, useCallback, useMemo } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { createClient } from "@/lib/supabase/client";
+import { queryKeys } from "@/lib/query-keys";
 import type { Category } from "@/types";
 
 export function useCategories(householdId: string | null) {
   const supabase = useMemo(() => createClient(), []);
-  const [categories, setCategories] = useState<Category[]>([]);
-  const [loading, setLoading] = useState(true);
+  const queryClient = useQueryClient();
 
-  const fetchCategories = useCallback(async () => {
-    if (!householdId) return;
+  const fetchCategories = useCallback(async (): Promise<Category[]> => {
+    if (!householdId) return [];
     const { data, error } = await supabase
       .from("categories")
       .select("*")
       .eq("household_id", householdId)
       .order("sort_order");
 
-    if (error) toast.error("カテゴリの取得に失敗しました");
-    if (data) setCategories(data);
-    setLoading(false);
+    if (error) throw error;
+    return data ?? [];
   }, [householdId, supabase]);
 
+  const query = useQuery({
+    queryKey: queryKeys.categories(householdId),
+    queryFn: fetchCategories,
+    enabled: !!householdId,
+  });
+
+  const categories = useMemo(() => query.data ?? [], [query.data]);
+  const loading = !householdId || query.isLoading;
+
   useEffect(() => {
-    fetchCategories();
-  }, [fetchCategories]);
+    if (query.isError) toast.error("カテゴリの取得に失敗しました");
+  }, [query.isError]);
+
+  const setCategories = useCallback<React.Dispatch<React.SetStateAction<Category[]>>>(
+    (update) => {
+      queryClient.setQueryData<Category[]>(queryKeys.categories(householdId), (old) => {
+        const prev = old ?? [];
+        return typeof update === "function"
+          ? (update as (p: Category[]) => Category[])(prev)
+          : update;
+      });
+    },
+    [queryClient, householdId]
+  );
 
   const addCategory = async (name: string, color: string) => {
     if (!householdId) return;
@@ -80,9 +101,9 @@ export function useCategories(householdId: string | null) {
     );
     if (results.some((r) => r.error)) {
       toast.error("カテゴリの並び替えに失敗しました");
-      fetchCategories();
+      query.refetch();
     }
   };
 
-  return { categories, loading, addCategory, updateCategory, deleteCategory, reorderCategories, refetch: fetchCategories };
+  return { categories, loading, addCategory, updateCategory, deleteCategory, reorderCategories, refetch: query.refetch };
 }

--- a/src/hooks/use-staple-items.ts
+++ b/src/hooks/use-staple-items.ts
@@ -1,17 +1,18 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useEffect, useCallback, useMemo } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { createClient } from "@/lib/supabase/client";
+import { queryKeys } from "@/lib/query-keys";
 import type { StapleItem } from "@/types";
 
 export function useStapleItems(householdId: string | null) {
   const supabase = useMemo(() => createClient(), []);
-  const [stapleItems, setStapleItems] = useState<StapleItem[]>([]);
-  const [loading, setLoading] = useState(true);
+  const queryClient = useQueryClient();
 
-  const fetchStapleItems = useCallback(async () => {
-    if (!householdId) return;
+  const fetchStapleItems = useCallback(async (): Promise<StapleItem[]> => {
+    if (!householdId) return [];
     const { data, error } = await supabase
       .from("staple_items")
       .select("*")
@@ -19,14 +20,34 @@ export function useStapleItems(householdId: string | null) {
       .order("sort_order")
       .order("created_at", { ascending: true });
 
-    if (error) toast.error("定番品の取得に失敗しました");
-    if (data) setStapleItems(data);
-    setLoading(false);
+    if (error) throw error;
+    return data ?? [];
   }, [householdId, supabase]);
 
+  const query = useQuery({
+    queryKey: queryKeys.stapleItems(householdId),
+    queryFn: fetchStapleItems,
+    enabled: !!householdId,
+  });
+
+  const stapleItems = useMemo(() => query.data ?? [], [query.data]);
+  const loading = !householdId || query.isLoading;
+
   useEffect(() => {
-    fetchStapleItems();
-  }, [fetchStapleItems]);
+    if (query.isError) toast.error("定番品の取得に失敗しました");
+  }, [query.isError]);
+
+  const setStapleItems = useCallback<React.Dispatch<React.SetStateAction<StapleItem[]>>>(
+    (update) => {
+      queryClient.setQueryData<StapleItem[]>(queryKeys.stapleItems(householdId), (old) => {
+        const prev = old ?? [];
+        return typeof update === "function"
+          ? (update as (p: StapleItem[]) => StapleItem[])(prev)
+          : update;
+      });
+    },
+    [queryClient, householdId]
+  );
 
   const addStapleItem = async (item: {
     name: string;
@@ -162,6 +183,6 @@ export function useStapleItems(householdId: string | null) {
     deleteStapleItem,
     reorderStapleItems,
     recordUsage,
-    refetch: fetchStapleItems,
+    refetch: query.refetch,
   };
 }

--- a/src/hooks/use-tasks.test.ts
+++ b/src/hooks/use-tasks.test.ts
@@ -3,9 +3,10 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { useTasks } from "@/hooks/use-tasks";
 import { createClient } from "@/lib/supabase/client";
 import { MockQueryChain, createMockSupabase } from "@/test/mocks/supabase";
+import { createQueryWrapper } from "@/test/query-wrapper";
 import type { Task } from "@/types";
 
-vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+vi.mock("sonner", () => ({ toast: Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn() }) }));
 vi.mock("@/lib/push", () => ({ sendPushNotification: vi.fn() }));
 vi.mock("@/lib/supabase/client");
 
@@ -47,7 +48,7 @@ describe("useTasks", () => {
       const task = makeTask();
       chain._result = { data: [task], error: null };
 
-      const { result } = renderHook(() => useTasks(HOUSEHOLD_ID));
+      const { result } = renderHook(() => useTasks(HOUSEHOLD_ID), { wrapper: createQueryWrapper() });
 
       await waitFor(() => expect(result.current.loading).toBe(false));
       expect(result.current.tasks).toEqual([task]);
@@ -55,7 +56,7 @@ describe("useTasks", () => {
 
     it("ソート順: is_done, sort_order, created_at DESC で order を呼ぶ", async () => {
       chain._result = { data: [], error: null };
-      renderHook(() => useTasks(HOUSEHOLD_ID));
+      renderHook(() => useTasks(HOUSEHOLD_ID), { wrapper: createQueryWrapper() });
 
       await waitFor(() => expect(chain.order).toHaveBeenCalled());
       expect(chain.order).toHaveBeenNthCalledWith(1, "is_done");
@@ -65,7 +66,7 @@ describe("useTasks", () => {
 
     it("完了済みは直近のみ: 未完了 OR 直近完了に絞る or フィルタを呼ぶ", async () => {
       chain._result = { data: [], error: null };
-      renderHook(() => useTasks(HOUSEHOLD_ID));
+      renderHook(() => useTasks(HOUSEHOLD_ID), { wrapper: createQueryWrapper() });
 
       await waitFor(() => expect(chain.or).toHaveBeenCalled());
       expect(chain.or).toHaveBeenCalledWith(
@@ -77,7 +78,7 @@ describe("useTasks", () => {
   describe("addTask", () => {
     it("正常系: tasks にタスクを追加する", async () => {
       chain._result = { data: [], error: null };
-      const { result } = renderHook(() => useTasks(HOUSEHOLD_ID));
+      const { result } = renderHook(() => useTasks(HOUSEHOLD_ID), { wrapper: createQueryWrapper() });
       await waitFor(() => expect(result.current.loading).toBe(false));
 
       const serverTask = makeTask({ title: "買い物" });
@@ -87,12 +88,12 @@ describe("useTasks", () => {
         await result.current.addTask({ title: "買い物" });
       });
 
-      expect(result.current.tasks).toContainEqual(serverTask);
+      await waitFor(() => expect(result.current.tasks).toContainEqual(serverTask));
     });
 
     it("エラー時: optimistic update をロールバックする", async () => {
       chain._result = { data: [], error: null };
-      const { result } = renderHook(() => useTasks(HOUSEHOLD_ID));
+      const { result } = renderHook(() => useTasks(HOUSEHOLD_ID), { wrapper: createQueryWrapper() });
       await waitFor(() => expect(result.current.loading).toBe(false));
 
       chain.single.mockResolvedValueOnce({ data: null, error: { message: "DB error" } });
@@ -109,7 +110,7 @@ describe("useTasks", () => {
     it("未完了→完了: is_done=true, completed_at がセットされる", async () => {
       const task = makeTask({ id: "t-1", is_done: false, completed_at: null });
       chain._result = { data: [task], error: null };
-      const { result } = renderHook(() => useTasks(HOUSEHOLD_ID));
+      const { result } = renderHook(() => useTasks(HOUSEHOLD_ID), { wrapper: createQueryWrapper() });
       await waitFor(() => expect(result.current.tasks).toHaveLength(1));
 
       const updatedTask = makeTask({
@@ -123,7 +124,7 @@ describe("useTasks", () => {
         await result.current.toggleTask("t-1");
       });
 
-      expect(result.current.tasks[0].is_done).toBe(true);
+      await waitFor(() => expect(result.current.tasks[0].is_done).toBe(true));
       expect(result.current.tasks[0].completed_at).not.toBeNull();
     });
 
@@ -134,7 +135,7 @@ describe("useTasks", () => {
         completed_at: "2024-01-01T12:00:00Z",
       });
       chain._result = { data: [task], error: null };
-      const { result } = renderHook(() => useTasks(HOUSEHOLD_ID));
+      const { result } = renderHook(() => useTasks(HOUSEHOLD_ID), { wrapper: createQueryWrapper() });
       await waitFor(() => expect(result.current.tasks).toHaveLength(1));
 
       const updatedTask = makeTask({ id: "t-1", is_done: false, completed_at: null });
@@ -144,7 +145,7 @@ describe("useTasks", () => {
         await result.current.toggleTask("t-1");
       });
 
-      expect(result.current.tasks[0].is_done).toBe(false);
+      await waitFor(() => expect(result.current.tasks[0].is_done).toBe(false));
       expect(result.current.tasks[0].completed_at).toBeNull();
     });
   });
@@ -153,7 +154,7 @@ describe("useTasks", () => {
     it("ホワイトリスト外のフィールドは update 呼び出しに含まれない", async () => {
       const task = makeTask({ id: "t-1" });
       chain._result = { data: [task], error: null };
-      const { result } = renderHook(() => useTasks(HOUSEHOLD_ID));
+      const { result } = renderHook(() => useTasks(HOUSEHOLD_ID), { wrapper: createQueryWrapper() });
       await waitFor(() => expect(result.current.tasks).toHaveLength(1));
 
       chain.single.mockResolvedValueOnce({ data: task, error: null });
@@ -177,7 +178,7 @@ describe("useTasks", () => {
       const { sendPushNotification } = await import("@/lib/push");
       const task = makeTask({ id: "t-1", title: "掃除" });
       chain._result = { data: [task], error: null };
-      const { result } = renderHook(() => useTasks(HOUSEHOLD_ID));
+      const { result } = renderHook(() => useTasks(HOUSEHOLD_ID), { wrapper: createQueryWrapper() });
       await waitFor(() => expect(result.current.tasks).toHaveLength(1));
 
       const updatedTask = makeTask({ id: "t-1", title: "新しいタイトル" });
@@ -199,7 +200,7 @@ describe("useTasks", () => {
       vi.mocked(sendPushNotification).mockClear();
       const task = makeTask({ id: "t-1" });
       chain._result = { data: [task], error: null };
-      const { result } = renderHook(() => useTasks(HOUSEHOLD_ID));
+      const { result } = renderHook(() => useTasks(HOUSEHOLD_ID), { wrapper: createQueryWrapper() });
       await waitFor(() => expect(result.current.tasks).toHaveLength(1));
 
       chain.single.mockResolvedValueOnce({ data: task, error: null });
@@ -216,21 +217,21 @@ describe("useTasks", () => {
     it("正常系: tasks からタスクが削除される", async () => {
       const task = makeTask({ id: "t-1" });
       chain._result = { data: [task], error: null };
-      const { result } = renderHook(() => useTasks(HOUSEHOLD_ID));
+      const { result } = renderHook(() => useTasks(HOUSEHOLD_ID), { wrapper: createQueryWrapper() });
       await waitFor(() => expect(result.current.tasks).toHaveLength(1));
 
       await act(async () => {
         await result.current.deleteTask("t-1");
       });
 
-      expect(result.current.tasks).toHaveLength(0);
+      await waitFor(() => expect(result.current.tasks).toHaveLength(0));
     });
   });
 
   describe("reorderTasks", () => {
     it("reorder_tasks RPC が正しい引数で呼ばれる", async () => {
       chain._result = { data: [], error: null };
-      const { result } = renderHook(() => useTasks(HOUSEHOLD_ID));
+      const { result } = renderHook(() => useTasks(HOUSEHOLD_ID), { wrapper: createQueryWrapper() });
       await waitFor(() => expect(result.current.loading).toBe(false));
 
       await act(async () => {

--- a/src/hooks/use-tasks.ts
+++ b/src/hooks/use-tasks.ts
@@ -1,8 +1,10 @@
 "use client";
 
-import { useState, useEffect, useCallback, useMemo } from "react";
+import { useEffect, useCallback, useMemo } from "react";
+import { useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
 import { createClient } from "@/lib/supabase/client";
+import { queryKeys } from "@/lib/query-keys";
 import { sendPushNotification } from "@/lib/push";
 import type { Task } from "@/types";
 
@@ -11,11 +13,10 @@ const COMPLETED_TASKS_WINDOW_DAYS = 30;
 
 export function useTasks(householdId: string | null) {
   const supabase = useMemo(() => createClient(), []);
-  const [tasks, setTasks] = useState<Task[]>([]);
-  const [loading, setLoading] = useState(true);
+  const queryClient = useQueryClient();
 
-  const fetchTasks = useCallback(async () => {
-    if (!householdId) return;
+  const fetchTasks = useCallback(async (): Promise<Task[]> => {
+    if (!householdId) return [];
 
     const completedCutoff = new Date(
       Date.now() - COMPLETED_TASKS_WINDOW_DAYS * 24 * 60 * 60 * 1000
@@ -30,14 +31,37 @@ export function useTasks(householdId: string | null) {
       .order("sort_order")
       .order("created_at", { ascending: false });
 
-    if (error) toast.error("タスクの取得に失敗しました");
-    if (data) setTasks(data);
-    setLoading(false);
+    if (error) throw error;
+    return data ?? [];
   }, [householdId, supabase]);
 
+  const query = useQuery({
+    queryKey: queryKeys.tasks(householdId),
+    queryFn: fetchTasks,
+    enabled: !!householdId,
+  });
+
+  const tasks = useMemo(() => query.data ?? [], [query.data]);
+  // householdId 確定前は skeleton を維持する（query は disabled で isLoading=false になるため）
+  const loading = !householdId || query.isLoading;
+
   useEffect(() => {
-    fetchTasks();
-  }, [fetchTasks]);
+    if (query.isError) toast.error("タスクの取得に失敗しました");
+  }, [query.isError]);
+
+  // 既存の setTasks 互換 API。Realtime フックや楽観的更新はこの関数経由で
+  // React Query キャッシュを更新する（ページ遷移をまたいで状態が永続する）
+  const setTasks = useCallback<React.Dispatch<React.SetStateAction<Task[]>>>(
+    (update) => {
+      queryClient.setQueryData<Task[]>(queryKeys.tasks(householdId), (old) => {
+        const prev = old ?? [];
+        return typeof update === "function"
+          ? (update as (p: Task[]) => Task[])(prev)
+          : update;
+      });
+    },
+    [queryClient, householdId]
+  );
 
   const addTask = async (task: {
     title: string;
@@ -216,5 +240,5 @@ export function useTasks(householdId: string | null) {
     }
   };
 
-  return { tasks, setTasks, loading, addTask, updateTask, deleteTask, toggleTask, reorderTasks, refetch: fetchTasks };
+  return { tasks, setTasks, loading, addTask, updateTask, deleteTask, toggleTask, reorderTasks, refetch: query.refetch };
 }

--- a/src/lib/query-keys.ts
+++ b/src/lib/query-keys.ts
@@ -1,0 +1,5 @@
+export const queryKeys = {
+  tasks: (householdId: string | null) => ["tasks", householdId] as const,
+  categories: (householdId: string | null) => ["categories", householdId] as const,
+  stapleItems: (householdId: string | null) => ["staple-items", householdId] as const,
+};

--- a/src/test/query-wrapper.tsx
+++ b/src/test/query-wrapper.tsx
@@ -1,0 +1,15 @@
+import type { ReactNode } from "react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+
+// テストごとに独立した QueryClient を持つ wrapper を生成する。
+// retry を切り、gcTime=0 でテスト間のキャッシュ漏れを防ぐ。
+export function createQueryWrapper() {
+  const queryClient = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+    },
+  });
+  return function Wrapper({ children }: { children: ReactNode }) {
+    return <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>;
+  };
+}


### PR DESCRIPTION
タスク・カテゴリ・定番品の取得を useState+useEffect から
@tanstack/react-query の useQuery に移行。SPA セッション内で
キャッシュを永続化し、stale-while-revalidate で遷移直後にキャッシュを
即時表示する。setTasks 等は setQueryData アダプタに置換したため、
楽観的更新・Realtime 連携・undo ロジックは変更せず維持している。

https://claude.ai/code/session_01VKnfS2Vc6QXYVd6ZsEbkLk