### PR TITLE
test: sonner モックの toast を呼び出し可能にする

### DIFF
--- a/src/components/category/category-manager.tsx
+++ b/src/components/category/category-manager.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { Pencil, Trash2, Plus, GripVertical } from "lucide-react";
+import { Plus } from "lucide-react";
 import {
   DndContext,
   DragEndEvent,
@@ -17,10 +17,10 @@ import {
   SortableContext,
   verticalListSortingStrategy,
   arrayMove,
-  useSortable,
 } from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
 import { Button } from "@/components/ui/button";
+import { ColorPicker, PRESET_COLORS } from "@/components/category/color-picker";
+import { SortableCategoryRow, CategoryRowOverlay } from "@/components/category/sortable-category-row";
 import type { Category } from "@/types";
 
 interface CategoryManagerProps {
@@ -29,115 +29,6 @@ interface CategoryManagerProps {
   onUpdate: (id: string, updates: { name?: string; color?: string }) => Promise<void>;
   onDelete: (id: string) => Promise<void>;
   onReorder: (orderedIds: string[]) => Promise<void>;
-}
-
-const PRESET_COLORS = [
-  "#ef4444", "#f97316", "#eab308", "#22c55e",
-  "#3b82f6", "#6366f1", "#a855f7", "#ec4899",
-];
-
-interface SortableCategoryRowProps {
-  cat: Category;
-  editingId: string | null;
-  name: string;
-  color: string;
-  onNameChange: (v: string) => void;
-  onColorChange: (c: string) => void;
-  onStartEdit: (cat: Category) => void;
-  onUpdate: (id: string) => void;
-  onCancelEdit: () => void;
-  onDelete: (id: string) => void;
-}
-
-function SortableCategoryRow({
-  cat,
-  editingId,
-  name,
-  color,
-  onNameChange,
-  onColorChange,
-  onStartEdit,
-  onUpdate,
-  onCancelEdit,
-  onDelete,
-}: SortableCategoryRowProps) {
-  const isEditing = editingId === cat.id;
-  const {
-    attributes,
-    listeners,
-    setNodeRef,
-    transform,
-    transition,
-    isDragging,
-  } = useSortable({ id: cat.id, disabled: isEditing });
-
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-    opacity: isDragging ? 0.4 : 1,
-  };
-
-  return (
-    <div ref={setNodeRef} style={style} className="flex items-center gap-2">
-      {isEditing ? (
-        <div className="flex flex-1 flex-col gap-2">
-          <input
-            value={name}
-            onChange={(e) => onNameChange(e.target.value)}
-            maxLength={50}
-            className="rounded border border-border-strong bg-surface px-3 py-2 text-sm text-foreground outline-none focus:border-focus focus:ring-2 focus:ring-focus/15"
-            autoFocus
-          />
-          <div className="flex gap-1.5">
-            {PRESET_COLORS.map((c) => (
-              <button
-                key={c}
-                onClick={() => onColorChange(c)}
-                className={`h-6 w-6 rounded-full border-2 ${color === c ? "border-foreground" : "border-transparent"}`}
-                style={{ backgroundColor: c }}
-              />
-            ))}
-          </div>
-          <div className="flex gap-2">
-            <Button size="sm" onClick={() => onUpdate(cat.id)}>保存</Button>
-            <Button size="sm" variant="ghost" onClick={onCancelEdit}>キャンセル</Button>
-          </div>
-        </div>
-      ) : (
-        <>
-          <button
-            {...attributes}
-            {...listeners}
-            className="touch-none cursor-grab p-1 text-subtle hover:text-muted active:cursor-grabbing shrink-0"
-            tabIndex={-1}
-          >
-            <GripVertical size={16} />
-          </button>
-          <div
-            className="h-4 w-4 rounded-full shrink-0"
-            style={{ backgroundColor: cat.color }}
-          />
-          <span className="flex-1 text-sm text-foreground">{cat.name}</span>
-          <button onClick={() => onStartEdit(cat)} className="p-1 text-subtle hover:text-foreground">
-            <Pencil size={16} />
-          </button>
-          <button onClick={() => onDelete(cat.id)} className="p-1 text-subtle hover:text-danger">
-            <Trash2 size={16} />
-          </button>
-        </>
-      )}
-    </div>
-  );
-}
-
-function CategoryRowOverlay({ cat }: { cat: Category }) {
-  return (
-    <div className="flex items-center gap-2 rounded-lg bg-surface px-2 py-1 shadow-md opacity-90 border border-border">
-      <GripVertical size={16} className="text-subtle shrink-0" />
-      <div className="h-4 w-4 rounded-full shrink-0" style={{ backgroundColor: cat.color }} />
-      <span className="flex-1 text-sm text-foreground">{cat.name}</span>
-    </div>
-  );
 }
 
 export function CategoryManager({ categories, onAdd, onUpdate, onDelete, onReorder }: CategoryManagerProps) {
@@ -230,16 +121,7 @@ export function CategoryManager({ categories, onAdd, onUpdate, onDelete, onReord
             className="rounded border border-border-strong bg-surface px-3 py-2 text-sm text-foreground outline-none focus:border-focus focus:ring-2 focus:ring-focus/15"
             autoFocus
           />
-          <div className="flex gap-1.5">
-            {PRESET_COLORS.map((c) => (
-              <button
-                key={c}
-                onClick={() => setColor(c)}
-                className={`h-6 w-6 rounded-full border-2 ${color === c ? "border-foreground" : "border-transparent"}`}
-                style={{ backgroundColor: c }}
-              />
-            ))}
-          </div>
+          <ColorPicker value={color} onChange={setColor} />
           <div className="flex gap-2">
             <Button size="sm" onClick={handleAdd}>追加</Button>
             <Button size="sm" variant="ghost" onClick={() => { setIsAdding(false); setName(""); }}>キャンセル</Button>

--- a/src/components/category/color-picker.tsx
+++ b/src/components/category/color-picker.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+export const PRESET_COLORS = [
+  "#ef4444", "#f97316", "#eab308", "#22c55e",
+  "#3b82f6", "#6366f1", "#a855f7", "#ec4899",
+];
+
+interface ColorPickerProps {
+  value: string;
+  onChange: (color: string) => void;
+}
+
+export function ColorPicker({ value, onChange }: ColorPickerProps) {
+  return (
+    <div className="flex gap-1.5">
+      {PRESET_COLORS.map((c) => (
+        <button
+          key={c}
+          onClick={() => onChange(c)}
+          className={`h-6 w-6 rounded-full border-2 ${value === c ? "border-foreground" : "border-transparent"}`}
+          style={{ backgroundColor: c }}
+        />
+      ))}
+    </div>
+  );
+}

--- a/src/components/category/sortable-category-row.tsx
+++ b/src/components/category/sortable-category-row.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { Pencil, Trash2, GripVertical } from "lucide-react";
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { Button } from "@/components/ui/button";
+import { ColorPicker } from "@/components/category/color-picker";
+import type { Category } from "@/types";
+
+interface SortableCategoryRowProps {
+  cat: Category;
+  editingId: string | null;
+  name: string;
+  color: string;
+  onNameChange: (v: string) => void;
+  onColorChange: (c: string) => void;
+  onStartEdit: (cat: Category) => void;
+  onUpdate: (id: string) => void;
+  onCancelEdit: () => void;
+  onDelete: (id: string) => void;
+}
+
+export function SortableCategoryRow({
+  cat,
+  editingId,
+  name,
+  color,
+  onNameChange,
+  onColorChange,
+  onStartEdit,
+  onUpdate,
+  onCancelEdit,
+  onDelete,
+}: SortableCategoryRowProps) {
+  const isEditing = editingId === cat.id;
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: cat.id, disabled: isEditing });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+    opacity: isDragging ? 0.4 : 1,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} className="flex items-center gap-2">
+      {isEditing ? (
+        <div className="flex flex-1 flex-col gap-2">
+          <input
+            value={name}
+            onChange={(e) => onNameChange(e.target.value)}
+            maxLength={50}
+            className="rounded border border-border-strong bg-surface px-3 py-2 text-sm text-foreground outline-none focus:border-focus focus:ring-2 focus:ring-focus/15"
+            autoFocus
+          />
+          <ColorPicker value={color} onChange={onColorChange} />
+          <div className="flex gap-2">
+            <Button size="sm" onClick={() => onUpdate(cat.id)}>保存</Button>
+            <Button size="sm" variant="ghost" onClick={onCancelEdit}>キャンセル</Button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <button
+            {...attributes}
+            {...listeners}
+            className="touch-none cursor-grab p-1 text-subtle hover:text-muted active:cursor-grabbing shrink-0"
+            tabIndex={-1}
+          >
+            <GripVertical size={16} />
+          </button>
+          <div
+            className="h-4 w-4 rounded-full shrink-0"
+            style={{ backgroundColor: cat.color }}
+          />
+          <span className="flex-1 text-sm text-foreground">{cat.name}</span>
+          <button onClick={() => onStartEdit(cat)} className="p-1 text-subtle hover:text-foreground">
+            <Pencil size={16} />
+          </button>
+          <button onClick={() => onDelete(cat.id)} className="p-1 text-subtle hover:text-danger">
+            <Trash2 size={16} />
+          </button>
+        </>
+      )}
+    </div>
+  );
+}
+
+export function CategoryRowOverlay({ cat }: { cat: Category }) {
+  return (
+    <div className="flex items-center gap-2 rounded-lg bg-surface px-2 py-1 shadow-md opacity-90 border border-border">
+      <GripVertical size={16} className="text-subtle shrink-0" />
+      <div className="h-4 w-4 rounded-full shrink-0" style={{ backgroundColor: cat.color }} />
+      <span className="flex-1 text-sm text-foreground">{cat.name}</span>
+    </div>
+  );
+}

--- a/src/components/staple/sortable-staple-card.tsx
+++ b/src/components/staple/sortable-staple-card.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { useSortable } from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
+import { StapleItemCard } from "@/components/staple/staple-item-card";
+import type { StapleItem, Category } from "@/types";
+
+interface SortableStapleCardProps {
+  item: StapleItem;
+  categories: Category[];
+  isEditMode: boolean;
+  onAddToTask: (item: StapleItem) => void;
+  onLongPress: (item: StapleItem) => void;
+  onDelete: (id: string) => void;
+}
+
+export function SortableStapleCard(props: SortableStapleCardProps) {
+  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
+    id: props.item.id,
+    disabled: !props.isEditMode,
+  });
+
+  const style = {
+    transform: CSS.Transform.toString(transform),
+    transition,
+  };
+
+  return (
+    <div ref={setNodeRef} style={style} className="h-full" {...(props.isEditMode ? { ...attributes, ...listeners } : {})}>
+      <StapleItemCard {...props} isDragging={isDragging} />
+    </div>
+  );
+}

--- a/src/components/staple/staple-items-sheet.tsx
+++ b/src/components/staple/staple-items-sheet.tsx
@@ -13,112 +13,15 @@ import {
 } from "@dnd-kit/core";
 import {
   SortableContext,
-  useSortable,
   rectSortingStrategy,
   arrayMove,
 } from "@dnd-kit/sortable";
-import { CSS } from "@dnd-kit/utilities";
 import { toast } from "sonner";
 import { BottomSheet } from "@/components/ui/bottom-sheet";
-import { StapleItemCard } from "@/components/staple/staple-item-card";
 import { StapleItemFormSheet } from "@/components/staple/staple-item-form-sheet";
+import { SortableStapleCard } from "@/components/staple/sortable-staple-card";
+import { StapleQuickAddSheet } from "@/components/staple/staple-quick-add-sheet";
 import type { StapleItem, Category } from "@/types";
-
-interface SortableStapleCardProps {
-  item: StapleItem;
-  categories: Category[];
-  isEditMode: boolean;
-  onAddToTask: (item: StapleItem) => void;
-  onLongPress: (item: StapleItem) => void;
-  onDelete: (id: string) => void;
-}
-
-function SortableStapleCard(props: SortableStapleCardProps) {
-  const { attributes, listeners, setNodeRef, transform, transition, isDragging } = useSortable({
-    id: props.item.id,
-    disabled: !props.isEditMode,
-  });
-
-  const style = {
-    transform: CSS.Transform.toString(transform),
-    transition,
-  };
-
-  return (
-    <div ref={setNodeRef} style={style} className="h-full" {...(props.isEditMode ? { ...attributes, ...listeners } : {})}>
-      <StapleItemCard {...props} isDragging={isDragging} />
-    </div>
-  );
-}
-
-interface QuickAddSheetProps {
-  isOpen: boolean;
-  item: StapleItem | null;
-  onClose: () => void;
-  onConfirm: (item: StapleItem, overrideQuantity: number | null, overrideNote: string | null) => void;
-}
-
-function QuickAddSheet({ isOpen, item, onClose, onConfirm }: QuickAddSheetProps) {
-  const [quantityStr, setQuantityStr] = useState("");
-  const [note, setNote] = useState("");
-
-  const handleOpen = useCallback(() => {
-    if (item) {
-      setQuantityStr(item.default_quantity !== null ? String(item.default_quantity) : "");
-      setNote(item.note ?? "");
-    }
-  }, [item]);
-
-  const handleSubmit = (e: React.FormEvent) => {
-    e.preventDefault();
-    if (!item) return;
-    const quantity = quantityStr ? parseFloat(quantityStr) : null;
-    onConfirm(item, quantity !== null && !isNaN(quantity) ? quantity : null, note.trim() || null);
-    onClose();
-  };
-
-  return (
-    <BottomSheet
-      isOpen={isOpen}
-      onClose={onClose}
-      title={item?.name ?? ""}
-      elevated
-    >
-      <form onSubmit={handleSubmit} className="flex flex-col gap-4" onAnimationStart={handleOpen}>
-        <p className="text-sm text-muted">数量・メモを調整してリストに追加できます</p>
-        <div className="flex items-center gap-2">
-          <input
-            type="number"
-            inputMode="decimal"
-            value={quantityStr}
-            onChange={(e) => setQuantityStr(e.target.value)}
-            placeholder="数量"
-            min="0"
-            step="0.5"
-            className="flex-1 rounded border border-border-strong bg-surface px-4 py-3 text-sm text-foreground placeholder:text-subtle outline-none focus:border-focus focus:ring-2 focus:ring-focus/15"
-          />
-          {item?.default_unit && (
-            <span className="text-sm text-muted">{item.default_unit}</span>
-          )}
-        </div>
-        <textarea
-          value={note}
-          onChange={(e) => setNote(e.target.value)}
-          placeholder="メモ（任意）"
-          rows={2}
-          maxLength={1000}
-          className="rounded border border-border-strong bg-surface px-4 py-3 text-sm text-foreground placeholder:text-subtle outline-none resize-none focus:border-focus focus:ring-2 focus:ring-focus/15"
-        />
-        <button
-          type="submit"
-          className="rounded-xl bg-primary px-4 py-3 text-sm font-semibold text-white active:bg-primary/90"
-        >
-          リストに追加
-        </button>
-      </form>
-    </BottomSheet>
-  );
-}
 
 interface StapleItemsSheetProps {
   isOpen: boolean;
@@ -420,7 +323,7 @@ export function StapleItemsSheet({
       />
 
       {/* クイック追加（長押し） */}
-      <QuickAddSheet
+      <StapleQuickAddSheet
         isOpen={isQuickAddOpen}
         item={quickAddItem}
         onClose={() => {

--- a/src/components/staple/staple-quick-add-sheet.tsx
+++ b/src/components/staple/staple-quick-add-sheet.tsx
@@ -1,0 +1,74 @@
+"use client";
+
+import { useState, useCallback } from "react";
+import { BottomSheet } from "@/components/ui/bottom-sheet";
+import type { StapleItem } from "@/types";
+
+interface StapleQuickAddSheetProps {
+  isOpen: boolean;
+  item: StapleItem | null;
+  onClose: () => void;
+  onConfirm: (item: StapleItem, overrideQuantity: number | null, overrideNote: string | null) => void;
+}
+
+export function StapleQuickAddSheet({ isOpen, item, onClose, onConfirm }: StapleQuickAddSheetProps) {
+  const [quantityStr, setQuantityStr] = useState("");
+  const [note, setNote] = useState("");
+
+  const handleOpen = useCallback(() => {
+    if (item) {
+      setQuantityStr(item.default_quantity !== null ? String(item.default_quantity) : "");
+      setNote(item.note ?? "");
+    }
+  }, [item]);
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    if (!item) return;
+    const quantity = quantityStr ? parseFloat(quantityStr) : null;
+    onConfirm(item, quantity !== null && !isNaN(quantity) ? quantity : null, note.trim() || null);
+    onClose();
+  };
+
+  return (
+    <BottomSheet
+      isOpen={isOpen}
+      onClose={onClose}
+      title={item?.name ?? ""}
+      elevated
+    >
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4" onAnimationStart={handleOpen}>
+        <p className="text-sm text-muted">数量・メモを調整してリストに追加できます</p>
+        <div className="flex items-center gap-2">
+          <input
+            type="number"
+            inputMode="decimal"
+            value={quantityStr}
+            onChange={(e) => setQuantityStr(e.target.value)}
+            placeholder="数量"
+            min="0"
+            step="0.5"
+            className="flex-1 rounded border border-border-strong bg-surface px-4 py-3 text-sm text-foreground placeholder:text-subtle outline-none focus:border-focus focus:ring-2 focus:ring-focus/15"
+          />
+          {item?.default_unit && (
+            <span className="text-sm text-muted">{item.default_unit}</span>
+          )}
+        </div>
+        <textarea
+          value={note}
+          onChange={(e) => setNote(e.target.value)}
+          placeholder="メモ（任意）"
+          rows={2}
+          maxLength={1000}
+          className="rounded border border-border-strong bg-surface px-4 py-3 text-sm text-foreground placeholder:text-subtle outline-none resize-none focus:border-focus focus:ring-2 focus:ring-focus/15"
+        />
+        <button
+          type="submit"
+          className="rounded-xl bg-primary px-4 py-3 text-sm font-semibold text-white active:bg-primary/90"
+        >
+          リストに追加
+        </button>
+      </form>
+    </BottomSheet>
+  );
+}

--- a/src/hooks/use-tasks.test.ts
+++ b/src/hooks/use-tasks.test.ts
@@ -5,7 +5,7 @@ import { createClient } from "@/lib/supabase/client";
 import { MockQueryChain, createMockSupabase } from "@/test/mocks/supabase";
 import type { Task } from "@/types";
 
-vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+vi.mock("sonner", () => ({ toast: Object.assign(vi.fn(), { error: vi.fn(), success: vi.fn() }) }));
 vi.mock("@/lib/push", () => ({ sendPushNotification: vi.fn() }));
 vi.mock("@/lib/supabase/client");
 


### PR DESCRIPTION
deleteTask の取り消しトーストは toast() を関数として呼ぶが、モックが
オブジェクトのみで callable でなかったため deleteTask のテストが失敗していた。
実際の sonner API に合わせて vi.fn() を割り当てる。

https://claude.ai/code/session_01CZCFb2eVqeTmjA7JVu7MgK