### PR TITLE
fix: useCategories の楽観的更新とロールバックをパターンに揃える

### DIFF
--- a/src/hooks/use-categories.test.ts
+++ b/src/hooks/use-categories.test.ts
@@ -90,5 +90,63 @@ describe("useCategories", () => {
       await waitFor(() => expect(result.current.categories[0].name).toBe("新名前"));
       expect(result.current.categories[0].color).toBe("#0000ff");
     });
+
+    it("エラー時: optimistic update をロールバックする", async () => {
+      const cat = makeCategory({ id: "c-1", name: "元の名前", color: "#0000ff" });
+      chain._result = { data: [cat], error: null };
+
+      const { result } = renderHook(() => useCategories(HOUSEHOLD_ID), { wrapper: createQueryWrapper() });
+      await waitFor(() => expect(result.current.categories).toHaveLength(1));
+
+      chain._result = { data: null, error: { message: "DB error" } };
+
+      await act(async () => {
+        await result.current.updateCategory("c-1", { name: "新しい名前" });
+      });
+
+      expect(result.current.categories[0].name).toBe("元の名前");
+    });
+  });
+
+  describe("reorderCategories", () => {
+    it("正常系: 指定した順序に並び替わる", async () => {
+      const cats = [
+        makeCategory({ id: "c-1", sort_order: 0 }),
+        makeCategory({ id: "c-2", sort_order: 1 }),
+      ];
+      chain._result = { data: cats, error: null };
+
+      const { result } = renderHook(() => useCategories(HOUSEHOLD_ID), { wrapper: createQueryWrapper() });
+      await waitFor(() => expect(result.current.categories).toHaveLength(2));
+
+      await act(async () => {
+        await result.current.reorderCategories(["c-2", "c-1"]);
+      });
+
+      expect(result.current.categories[0].id).toBe("c-2");
+      expect(result.current.categories[1].id).toBe("c-1");
+    });
+
+    it("エラー時: snapshot にロールバックする", async () => {
+      const cats = [
+        makeCategory({ id: "c-1", sort_order: 0 }),
+        makeCategory({ id: "c-2", sort_order: 1 }),
+      ];
+      chain._result = { data: cats, error: null };
+
+      const { result } = renderHook(() => useCategories(HOUSEHOLD_ID), { wrapper: createQueryWrapper() });
+      await waitFor(() => expect(result.current.categories).toHaveLength(2));
+
+      chain._result = { data: null, error: { message: "DB error" } };
+
+      await act(async () => {
+        await result.current.reorderCategories(["c-2", "c-1"]);
+      });
+
+      await waitFor(() => {
+        expect(result.current.categories[0].id).toBe("c-1");
+        expect(result.current.categories[1].id).toBe("c-2");
+      });
+    });
   });
 });

--- a/src/hooks/use-categories.ts
+++ b/src/hooks/use-categories.ts
@@ -65,16 +65,20 @@ export function useCategories(householdId: string | null) {
   };
 
   const updateCategory = async (id: string, updates: Partial<Pick<Category, "name" | "color" | "icon" | "sort_order">>) => {
+    let snapshot = categories;
+    setCategories((prev) => {
+      snapshot = prev;
+      return prev.map((c) => (c.id === id ? { ...c, ...updates } : c));
+    });
+
     const { error } = await supabase
       .from("categories")
       .update(updates)
       .eq("id", id);
 
-    if (error) toast.error("カテゴリの更新に失敗しました");
-    if (!error) {
-      setCategories((prev) =>
-        prev.map((c) => (c.id === id ? { ...c, ...updates } : c))
-      );
+    if (error) {
+      setCategories(snapshot);
+      toast.error("カテゴリの更新に失敗しました");
     }
     return { error };
   };
@@ -90,7 +94,9 @@ export function useCategories(householdId: string | null) {
   };
 
   const reorderCategories = async (orderedIds: string[]) => {
+    let snapshot = categories;
     setCategories((prev) => {
+      snapshot = prev;
       const map = new Map(prev.map((c) => [c.id, c]));
       return orderedIds.map((id, i) => ({ ...map.get(id)!, sort_order: i }));
     });
@@ -100,8 +106,8 @@ export function useCategories(householdId: string | null) {
       )
     );
     if (results.some((r) => r.error)) {
+      setCategories(snapshot);
       toast.error("カテゴリの並び替えに失敗しました");
-      query.refetch();
     }
   };
 


### PR DESCRIPTION
updateCategory が DB 応答を待ってから state を更新する後付けパターンだったため、
use-tasks / use-staple-items と同じスナップショット方式の楽観的更新に変更。

reorderCategories はエラー時に query.refetch() でデータを再取得していたが、
既存スナップショットで即時ロールバックするよう修正（ネットワーク往復を削減）。

対応テストケースを use-categories.test.ts に追加。

https://claude.ai/code/session_01Jt4mnVAGfCfJLdyE2yDVXb