### PR TITLE
test: テストカバレッジを大幅に拡充

### DIFF
--- a/src/hooks/use-categories.test.ts
+++ b/src/hooks/use-categories.test.ts
@@ -57,6 +57,22 @@ describe("useCategories", () => {
       );
       await waitFor(() => expect(result.current.categories).toHaveLength(3));
     });
+
+    it("エラー時: state に追加されない", async () => {
+      const existing = [makeCategory({ sort_order: 0 })];
+      chain._result = { data: existing, error: null };
+
+      const { result } = renderHook(() => useCategories(HOUSEHOLD_ID), { wrapper: createQueryWrapper() });
+      await waitFor(() => expect(result.current.categories).toHaveLength(1));
+
+      chain.single.mockResolvedValueOnce({ data: null, error: { message: "DB error" } });
+
+      await act(async () => {
+        await result.current.addCategory("失敗カテゴリ", "#ff0000");
+      });
+
+      expect(result.current.categories).toHaveLength(1);
+    });
   });
 
   describe("deleteCategory", () => {
@@ -91,6 +107,21 @@ describe("useCategories", () => {
       expect(result.current.categories[0].color).toBe("#0000ff");
     });
 
+    it("color のみ変更して name は維持される", async () => {
+      const cat = makeCategory({ id: "c-1", name: "名前そのまま", color: "#0000ff" });
+      chain._result = { data: [cat], error: null };
+
+      const { result } = renderHook(() => useCategories(HOUSEHOLD_ID), { wrapper: createQueryWrapper() });
+      await waitFor(() => expect(result.current.categories).toHaveLength(1));
+
+      await act(async () => {
+        await result.current.updateCategory("c-1", { color: "#ff0000" });
+      });
+
+      await waitFor(() => expect(result.current.categories[0].color).toBe("#ff0000"));
+      expect(result.current.categories[0].name).toBe("名前そのまま");
+    });
+
     it("エラー時: optimistic update をロールバックする", async () => {
       const cat = makeCategory({ id: "c-1", name: "元の名前", color: "#0000ff" });
       chain._result = { data: [cat], error: null };
@@ -119,12 +150,23 @@ describe("useCategories", () => {
       const { result } = renderHook(() => useCategories(HOUSEHOLD_ID), { wrapper: createQueryWrapper() });
       await waitFor(() => expect(result.current.categories).toHaveLength(2));
 
+      // バックグラウンド再フェッチが起きても正しい順序を返すよう DB 状態を先に更新
+      chain._result = {
+        data: [
+          { ...cats[1], sort_order: 0 },
+          { ...cats[0], sort_order: 1 },
+        ],
+        error: null,
+      };
+
       await act(async () => {
         await result.current.reorderCategories(["c-2", "c-1"]);
       });
 
-      expect(result.current.categories[0].id).toBe("c-2");
-      expect(result.current.categories[1].id).toBe("c-1");
+      await waitFor(() => {
+        expect(result.current.categories[0].id).toBe("c-2");
+        expect(result.current.categories[1].id).toBe("c-1");
+      });
     });
 
     it("エラー時: snapshot にロールバックする", async () => {

--- a/src/hooks/use-page-data.test.ts
+++ b/src/hooks/use-page-data.test.ts
@@ -1,0 +1,169 @@
+import { renderHook, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { usePageData } from "@/hooks/use-page-data";
+import { createClient } from "@/lib/supabase/client";
+import { MockQueryChain } from "@/test/mocks/supabase";
+import type { Profile } from "@/types";
+
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+vi.mock("@/lib/supabase/client");
+
+// setup.ts の mock を上書きし、安定した参照を持つ router を用意する
+// (参照が毎 render で変わると useEffect の deps が変化して無限ループするため)
+const mockRouter = vi.hoisted(() => ({ push: vi.fn() }));
+vi.mock("next/navigation", () => ({
+  useRouter: () => mockRouter,
+  usePathname: () => "/",
+}));
+
+const HOUSEHOLD_ID = "household-1";
+const USER_ID = "user-1";
+
+function makeProfile(overrides: Partial<Profile> = {}): Profile {
+  return {
+    id: USER_ID,
+    household_id: HOUSEHOLD_ID,
+    nickname: "テスト太郎",
+    avatar_url: null,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+function makeSession(userId = USER_ID) {
+  return {
+    user: { id: userId, user_metadata: { nickname: "テスト太郎" } },
+  };
+}
+
+// usePageData が行うクエリ呼び出し順に対応したモッククライアントを構築する
+function buildMockClient({
+  session = makeSession() as ReturnType<typeof makeSession> | null,
+  profileData = makeProfile() as Profile | null,
+  profileError = null as { message: string } | null,
+  upsertProfileData = null as Profile | null,
+  members = [] as Profile[],
+} = {}) {
+  // 1回目: from("profiles") → select...maybeSingle でプロフィール取得
+  const profileFetchChain = new MockQueryChain();
+  profileFetchChain.maybeSingle = vi.fn().mockResolvedValue({ data: profileData, error: profileError });
+
+  // upsert 用チェーン（プロフィール未存在時に呼ばれる）
+  const profileUpsertChain = new MockQueryChain();
+  profileUpsertChain.single = vi.fn().mockResolvedValue({ data: upsertProfileData, error: null });
+
+  // バックグラウンドメンバー取得チェーン（thenable）
+  const membersFetchChain = new MockQueryChain();
+  membersFetchChain._result = { data: members, error: null };
+
+  // バックグラウンド世帯名取得チェーン
+  const householdNameChain = new MockQueryChain();
+  householdNameChain.single = vi.fn().mockResolvedValue({ data: { name: "テスト家族" }, error: null });
+
+  const fromMock = vi.fn()
+    .mockReturnValueOnce(profileFetchChain)   // profiles: マイプロフィール取得
+    .mockReturnValueOnce(profileUpsertChain)  // profiles: upsert（未存在時のみ消費される）
+    .mockReturnValueOnce(membersFetchChain)   // profiles: メンバー一覧
+    .mockReturnValue(householdNameChain);     // households: 世帯名
+
+  return {
+    auth: {
+      getSession: vi.fn().mockResolvedValue({
+        data: { session },
+        error: null,
+      }),
+    },
+    from: fromMock,
+  };
+}
+
+describe("usePageData", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("セッションなし: /login へリダイレクトし loading が false になる", async () => {
+    vi.mocked(createClient).mockReturnValue(
+      buildMockClient({ session: null }) as any
+    );
+
+    const { result } = renderHook(() => usePageData());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockRouter.push).toHaveBeenCalledWith("/login");
+    expect(result.current.profile).toBeNull();
+  });
+
+  it("プロフィールあり・household_id あり: profile がセットされ loading が false になる", async () => {
+    const profile = makeProfile();
+    vi.mocked(createClient).mockReturnValue(
+      buildMockClient({ profileData: profile }) as any
+    );
+
+    const { result } = renderHook(() => usePageData());
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.profile).toEqual(profile);
+    expect(mockRouter.push).not.toHaveBeenCalled();
+  });
+
+  it("household_id なし + redirectIfNoHousehold=true: /household/new へリダイレクト", async () => {
+    const profile = makeProfile({ household_id: null });
+    vi.mocked(createClient).mockReturnValue(
+      buildMockClient({ profileData: profile }) as any
+    );
+
+    const { result } = renderHook(() => usePageData({ redirectIfNoHousehold: true }));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockRouter.push).toHaveBeenCalledWith("/household/new");
+    expect(result.current.profile).toEqual(profile);
+  });
+
+  it("household_id なし + redirectIfNoHousehold=false: リダイレクトしない", async () => {
+    const profile = makeProfile({ household_id: null });
+    vi.mocked(createClient).mockReturnValue(
+      buildMockClient({ profileData: profile }) as any
+    );
+
+    const { result } = renderHook(() => usePageData({ redirectIfNoHousehold: false }));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(mockRouter.push).not.toHaveBeenCalled();
+    expect(result.current.profile).toEqual(profile);
+  });
+
+  it("プロフィール未存在: upsert で作成し profile がセットされる", async () => {
+    const newProfile = makeProfile({ household_id: null });
+    vi.mocked(createClient).mockReturnValue(
+      buildMockClient({
+        profileData: null,
+        upsertProfileData: newProfile,
+      }) as any
+    );
+
+    const { result } = renderHook(() => usePageData({ redirectIfNoHousehold: true }));
+    await waitFor(() => expect(result.current.loading).toBe(false));
+
+    expect(result.current.profile).toEqual(newProfile);
+    // household_id が null なので /household/new へリダイレクト
+    expect(mockRouter.push).toHaveBeenCalledWith("/household/new");
+  });
+
+  it("プロフィール取得エラー: toast.error が呼ばれる", async () => {
+    const { toast } = await import("sonner");
+    vi.mocked(createClient).mockReturnValue(
+      buildMockClient({
+        profileData: null,
+        profileError: { message: "DB error" },
+        upsertProfileData: makeProfile(),
+      }) as any
+    );
+
+    renderHook(() => usePageData());
+    await waitFor(() => {
+      expect(vi.mocked(toast.error)).toHaveBeenCalled();
+    });
+  });
+});

--- a/src/hooks/use-realtime-staple-items.test.ts
+++ b/src/hooks/use-realtime-staple-items.test.ts
@@ -1,0 +1,129 @@
+import { renderHook, act } from "@testing-library/react";
+import { useState } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useRealtimeStapleItems } from "@/hooks/use-realtime-staple-items";
+import { createClient } from "@/lib/supabase/client";
+import type { StapleItem } from "@/types";
+
+vi.mock("@/lib/supabase/client");
+
+const HOUSEHOLD_ID = "household-1";
+
+function makeStapleItem(overrides: Partial<StapleItem> = {}): StapleItem {
+  return {
+    id: crypto.randomUUID(),
+    household_id: HOUSEHOLD_ID,
+    name: "テストアイテム",
+    category_id: null,
+    default_quantity: null,
+    default_unit: null,
+    note: null,
+    icon: null,
+    sort_order: 0,
+    use_count: 0,
+    last_used_at: null,
+    created_by: null,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("useRealtimeStapleItems", () => {
+  let callbacks: Record<string, (payload: { new?: Partial<StapleItem>; old?: Partial<StapleItem> }) => void>;
+  let mockChannel: { on: ReturnType<typeof vi.fn>; subscribe: ReturnType<typeof vi.fn> };
+  let mockRemoveChannel: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    callbacks = {};
+    mockChannel = {
+      on: vi.fn().mockImplementation(
+        (_type: string, filter: { event: string }, cb: (p: any) => void) => {
+          callbacks[filter.event] = cb;
+          return mockChannel;
+        }
+      ),
+      subscribe: vi.fn().mockImplementation(() => mockChannel),
+    };
+    mockRemoveChannel = vi.fn();
+    vi.mocked(createClient).mockReturnValue({
+      channel: vi.fn().mockReturnValue(mockChannel),
+      removeChannel: mockRemoveChannel,
+    } as any);
+  });
+
+  function renderWithState(householdId: string | null, initialItems: StapleItem[] = []) {
+    return renderHook(() => {
+      const [items, setItems] = useState<StapleItem[]>(initialItems);
+      useRealtimeStapleItems(householdId, setItems);
+      return { items };
+    });
+  }
+
+  it("householdId がない場合はチャンネルを作成しない", () => {
+    renderWithState(null);
+    expect(vi.mocked(createClient)).not.toHaveBeenCalled();
+  });
+
+  it("householdId があれば staple_items チャンネルを購読する", () => {
+    renderWithState(HOUSEHOLD_ID);
+    const channel = vi.mocked(createClient)().channel;
+    expect(channel).toHaveBeenCalledWith(`staple_items:${HOUSEHOLD_ID}`);
+  });
+
+  it("INSERT: 新しいアイテムが state に追加される", () => {
+    const existing = makeStapleItem({ id: "si-1" });
+    const { result } = renderWithState(HOUSEHOLD_ID, [existing]);
+
+    const newItem = makeStapleItem({ id: "si-2" });
+    act(() => {
+      callbacks.INSERT({ new: newItem });
+    });
+
+    expect(result.current.items).toHaveLength(2);
+    expect(result.current.items.some((si) => si.id === "si-2")).toBe(true);
+  });
+
+  it("INSERT: 同じ id のアイテムは重複追加されない", () => {
+    const existing = makeStapleItem({ id: "si-1" });
+    const { result } = renderWithState(HOUSEHOLD_ID, [existing]);
+
+    act(() => {
+      callbacks.INSERT({ new: existing });
+    });
+
+    expect(result.current.items).toHaveLength(1);
+  });
+
+  it("UPDATE: 既存アイテムの内容が更新される", () => {
+    const item = makeStapleItem({ id: "si-1", name: "旧アイテム" });
+    const { result } = renderWithState(HOUSEHOLD_ID, [item]);
+
+    const updated = { ...item, name: "新アイテム" };
+    act(() => {
+      callbacks.UPDATE({ new: updated });
+    });
+
+    expect(result.current.items[0].name).toBe("新アイテム");
+  });
+
+  it("DELETE: 指定した id のアイテムが削除される", () => {
+    const si1 = makeStapleItem({ id: "si-1" });
+    const si2 = makeStapleItem({ id: "si-2" });
+    const { result } = renderWithState(HOUSEHOLD_ID, [si1, si2]);
+
+    act(() => {
+      callbacks.DELETE({ old: { id: "si-1" } });
+    });
+
+    expect(result.current.items).toHaveLength(1);
+    expect(result.current.items[0].id).toBe("si-2");
+  });
+
+  it("アンマウント時に removeChannel が呼ばれる", () => {
+    const { unmount } = renderWithState(HOUSEHOLD_ID);
+    unmount();
+    expect(mockRemoveChannel).toHaveBeenCalledWith(mockChannel);
+  });
+});

--- a/src/hooks/use-realtime-tasks.test.ts
+++ b/src/hooks/use-realtime-tasks.test.ts
@@ -1,0 +1,142 @@
+import { renderHook, act } from "@testing-library/react";
+import { useState } from "react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useRealtimeTasks } from "@/hooks/use-realtime-tasks";
+import { createClient } from "@/lib/supabase/client";
+import type { Task } from "@/types";
+
+vi.mock("@/lib/supabase/client");
+
+const HOUSEHOLD_ID = "household-1";
+
+function makeTask(overrides: Partial<Task> = {}): Task {
+  return {
+    id: crypto.randomUUID(),
+    title: "テストタスク",
+    category_id: null,
+    due_date: null,
+    memo: null,
+    url: null,
+    created_by: null,
+    household_id: HOUSEHOLD_ID,
+    is_done: false,
+    sort_order: 0,
+    completed_at: null,
+    created_at: "2024-01-01T00:00:00Z",
+    updated_at: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("useRealtimeTasks", () => {
+  // postgres_changes イベントのコールバックを捕捉するためのマップ
+  let callbacks: Record<string, (payload: { new?: Partial<Task>; old?: Partial<Task> }) => void>;
+  let mockChannel: { on: ReturnType<typeof vi.fn>; subscribe: ReturnType<typeof vi.fn> };
+  let mockRemoveChannel: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    callbacks = {};
+    mockChannel = {
+      on: vi.fn().mockImplementation(
+        (_type: string, filter: { event: string }, cb: (p: any) => void) => {
+          callbacks[filter.event] = cb;
+          return mockChannel;
+        }
+      ),
+      subscribe: vi.fn().mockImplementation(() => mockChannel),
+    };
+    mockRemoveChannel = vi.fn();
+    vi.mocked(createClient).mockReturnValue({
+      channel: vi.fn().mockReturnValue(mockChannel),
+      removeChannel: mockRemoveChannel,
+    } as any);
+  });
+
+  function renderWithState(householdId: string | null, initialTasks: Task[] = [], onRemoteChange?: () => void) {
+    return renderHook(() => {
+      const [tasks, setTasks] = useState<Task[]>(initialTasks);
+      useRealtimeTasks(householdId, setTasks, onRemoteChange);
+      return { tasks };
+    });
+  }
+
+  it("householdId がない場合はチャンネルを作成しない", () => {
+    renderWithState(null);
+    expect(vi.mocked(createClient)).not.toHaveBeenCalled();
+  });
+
+  it("householdId があればチャンネルを作成して購読する", () => {
+    renderWithState(HOUSEHOLD_ID);
+    const channel = vi.mocked(createClient)().channel;
+    expect(channel).toHaveBeenCalledWith(`tasks:${HOUSEHOLD_ID}`);
+    expect(mockChannel.subscribe).toHaveBeenCalled();
+  });
+
+  it("INSERT: 新しいタスクが state に追加される", () => {
+    const existing = makeTask({ id: "t-1" });
+    const { result } = renderWithState(HOUSEHOLD_ID, [existing]);
+
+    const newTask = makeTask({ id: "t-2" });
+    act(() => {
+      callbacks.INSERT({ new: newTask });
+    });
+
+    expect(result.current.tasks).toHaveLength(2);
+    expect(result.current.tasks.some((t) => t.id === "t-2")).toBe(true);
+  });
+
+  it("INSERT: 同じ id のタスクは重複追加されない（楽観的更新との競合防止）", () => {
+    const existing = makeTask({ id: "t-1" });
+    const { result } = renderWithState(HOUSEHOLD_ID, [existing]);
+
+    act(() => {
+      callbacks.INSERT({ new: existing });
+    });
+
+    expect(result.current.tasks).toHaveLength(1);
+  });
+
+  it("UPDATE: 既存タスクの内容が更新される", () => {
+    const task = makeTask({ id: "t-1", title: "旧タイトル" });
+    const { result } = renderWithState(HOUSEHOLD_ID, [task]);
+
+    const updated = { ...task, title: "新タイトル" };
+    act(() => {
+      callbacks.UPDATE({ new: updated });
+    });
+
+    expect(result.current.tasks[0].title).toBe("新タイトル");
+  });
+
+  it("DELETE: 指定した id のタスクが削除される", () => {
+    const t1 = makeTask({ id: "t-1" });
+    const t2 = makeTask({ id: "t-2" });
+    const { result } = renderWithState(HOUSEHOLD_ID, [t1, t2]);
+
+    act(() => {
+      callbacks.DELETE({ old: { id: "t-1" } });
+    });
+
+    expect(result.current.tasks).toHaveLength(1);
+    expect(result.current.tasks[0].id).toBe("t-2");
+  });
+
+  it("各イベントで onRemoteChange が呼ばれる", () => {
+    const onRemoteChange = vi.fn();
+    const task = makeTask({ id: "t-1" });
+    renderWithState(HOUSEHOLD_ID, [task], onRemoteChange);
+
+    act(() => { callbacks.INSERT({ new: makeTask({ id: "t-99" }) }); });
+    act(() => { callbacks.UPDATE({ new: task }); });
+    act(() => { callbacks.DELETE({ old: { id: "t-1" } }); });
+
+    expect(onRemoteChange).toHaveBeenCalledTimes(3);
+  });
+
+  it("アンマウント時に removeChannel が呼ばれる", () => {
+    const { unmount } = renderWithState(HOUSEHOLD_ID);
+    unmount();
+    expect(mockRemoveChannel).toHaveBeenCalledWith(mockChannel);
+  });
+});

--- a/src/hooks/use-sort.test.ts
+++ b/src/hooks/use-sort.test.ts
@@ -1,0 +1,60 @@
+import { renderHook, act } from "@testing-library/react";
+import { describe, it, expect, beforeEach } from "vitest";
+import { useSort } from "@/hooks/use-sort";
+
+const STORAGE_KEY = "task-sort-option";
+
+describe("useSort", () => {
+  beforeEach(() => {
+    localStorage.clear();
+  });
+
+  it("localStorage に値がない場合は manual がデフォルト", () => {
+    const { result } = renderHook(() => useSort());
+    expect(result.current.sortOption).toBe("manual");
+  });
+
+  it("localStorage に有効な値が保存されていればそれを読み込む", () => {
+    localStorage.setItem(STORAGE_KEY, "due_date");
+    const { result } = renderHook(() => useSort());
+    expect(result.current.sortOption).toBe("due_date");
+  });
+
+  it("localStorage に無効な値がある場合は manual にフォールバック", () => {
+    localStorage.setItem(STORAGE_KEY, "invalid_option");
+    const { result } = renderHook(() => useSort());
+    expect(result.current.sortOption).toBe("manual");
+  });
+
+  it("setSortOption が state を更新する", () => {
+    const { result } = renderHook(() => useSort());
+
+    act(() => {
+      result.current.setSortOption("created_desc");
+    });
+
+    expect(result.current.sortOption).toBe("created_desc");
+  });
+
+  it("setSortOption が localStorage に値を書き込む", () => {
+    const { result } = renderHook(() => useSort());
+
+    act(() => {
+      result.current.setSortOption("created_asc");
+    });
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBe("created_asc");
+  });
+
+  it("全ての有効オプションを受け付ける", () => {
+    const options = ["manual", "created_desc", "created_asc", "due_date"] as const;
+    const { result } = renderHook(() => useSort());
+
+    for (const option of options) {
+      act(() => {
+        result.current.setSortOption(option);
+      });
+      expect(result.current.sortOption).toBe(option);
+    }
+  });
+});

--- a/src/hooks/use-task-recommendations.test.ts
+++ b/src/hooks/use-task-recommendations.test.ts
@@ -1,0 +1,141 @@
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useTaskRecommendations } from "@/hooks/use-task-recommendations";
+import { createClient } from "@/lib/supabase/client";
+import { MockQueryChain, createMockSupabase } from "@/test/mocks/supabase";
+import type { TaskRecommendation } from "@/types";
+
+vi.mock("@/lib/supabase/client");
+vi.mock("@/lib/idle", () => ({
+  runWhenIdle: vi.fn((cb: () => void) => {
+    cb();
+    return vi.fn();
+  }),
+}));
+
+const HOUSEHOLD_ID = "household-1";
+const PROFILE_ID = "profile-1";
+
+function makeRecommendation(overrides: Partial<TaskRecommendation> = {}): TaskRecommendation {
+  return {
+    normalized_title: "掃除",
+    latest_title: "掃除する",
+    latest_category_id: null,
+    latest_memo: null,
+    median_interval_days: 7,
+    days_since_last: 10,
+    completion_count: 3,
+    last_completed_at: "2024-01-01T00:00:00Z",
+    ...overrides,
+  };
+}
+
+describe("useTaskRecommendations", () => {
+  let chain: MockQueryChain;
+  let mockClient: ReturnType<typeof createMockSupabase>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    chain = new MockQueryChain();
+    mockClient = createMockSupabase(chain);
+    // @ts-expect-error - モックオブジェクトは SupabaseClient の全インターフェースを実装しない
+    vi.mocked(createClient).mockReturnValue(mockClient as ReturnType<typeof createClient>);
+  });
+
+  it("householdId があれば RPC を呼び recommendations をセットする", async () => {
+    const recs = [makeRecommendation()];
+    mockClient.rpc.mockResolvedValue({ data: recs, error: null });
+
+    const { result } = renderHook(() =>
+      useTaskRecommendations(HOUSEHOLD_ID, PROFILE_ID)
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(mockClient.rpc).toHaveBeenCalledWith("get_recurring_recommendations");
+    expect(result.current.recommendations).toEqual(recs);
+  });
+
+  it("householdId が null の場合は RPC を呼ばず loading が true のまま", () => {
+    const { result } = renderHook(() => useTaskRecommendations(null));
+    expect(mockClient.rpc).not.toHaveBeenCalled();
+    expect(result.current.loading).toBe(true);
+  });
+
+  it("RPC エラーでも loading が false になる", async () => {
+    mockClient.rpc.mockResolvedValue({ data: null, error: { message: "RPC error" } });
+
+    const { result } = renderHook(() =>
+      useTaskRecommendations(HOUSEHOLD_ID)
+    );
+
+    await waitFor(() => expect(result.current.loading).toBe(false));
+    expect(result.current.recommendations).toHaveLength(0);
+  });
+
+  describe("dismiss", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("指定した normalized_title が state から除去される", async () => {
+      const rec1 = makeRecommendation({ normalized_title: "掃除" });
+      const rec2 = makeRecommendation({ normalized_title: "洗濯" });
+      mockClient.rpc.mockResolvedValue({ data: [rec1, rec2], error: null });
+
+      const { result } = renderHook(() =>
+        useTaskRecommendations(HOUSEHOLD_ID, PROFILE_ID)
+      );
+      await waitFor(() => expect(result.current.recommendations).toHaveLength(2));
+
+      await act(async () => {
+        await result.current.dismiss("掃除", 7);
+      });
+
+      expect(result.current.recommendations).toHaveLength(1);
+      expect(result.current.recommendations[0].normalized_title).toBe("洗濯");
+    });
+
+    it("dismissed_until が medianDays 分後の日付になっている", async () => {
+      const rec = makeRecommendation({ median_interval_days: 14 });
+      mockClient.rpc.mockResolvedValue({ data: [rec], error: null });
+
+      const { result } = renderHook(() =>
+        useTaskRecommendations(HOUSEHOLD_ID, PROFILE_ID)
+      );
+      // recommendations がロードされてから時刻を固定する（waitFor は setTimeout を使うため）
+      await waitFor(() => expect(result.current.recommendations).toHaveLength(1));
+
+      vi.useFakeTimers();
+      vi.setSystemTime(new Date("2024-06-15T12:00:00Z"));
+
+      await act(async () => {
+        await result.current.dismiss("掃除", 14);
+      });
+
+      const expectedDate = new Date("2024-06-29T12:00:00Z").toISOString();
+      expect(chain.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ dismissed_until: expectedDate }),
+        expect.any(Object)
+      );
+    });
+
+    it("profileId がある場合は dismissed_by に含まれる", async () => {
+      const rec = makeRecommendation();
+      mockClient.rpc.mockResolvedValue({ data: [rec], error: null });
+
+      const { result } = renderHook(() =>
+        useTaskRecommendations(HOUSEHOLD_ID, PROFILE_ID)
+      );
+      await waitFor(() => expect(result.current.recommendations).toHaveLength(1));
+
+      await act(async () => {
+        await result.current.dismiss("掃除", 7);
+      });
+
+      expect(chain.upsert).toHaveBeenCalledWith(
+        expect.objectContaining({ dismissed_by: PROFILE_ID }),
+        expect.any(Object)
+      );
+    });
+  });
+});

--- a/src/hooks/use-tasks.test.ts
+++ b/src/hooks/use-tasks.test.ts
@@ -226,6 +226,21 @@ describe("useTasks", () => {
 
       await waitFor(() => expect(result.current.tasks).toHaveLength(0));
     });
+
+    it("エラー時: 楽観的削除からロールバックする", async () => {
+      const task = makeTask({ id: "t-1" });
+      chain._result = { data: [task], error: null };
+      const { result } = renderHook(() => useTasks(HOUSEHOLD_ID), { wrapper: createQueryWrapper() });
+      await waitFor(() => expect(result.current.tasks).toHaveLength(1));
+
+      chain._result = { data: null, error: { message: "DB error" } };
+
+      await act(async () => {
+        await result.current.deleteTask("t-1", { skipToast: true });
+      });
+
+      await waitFor(() => expect(result.current.tasks).toHaveLength(1));
+    });
   });
 
   describe("reorderTasks", () => {
@@ -302,6 +317,28 @@ describe("useTasks", () => {
       });
 
       expect(result.current.hasMoreCompleted).toBe(false);
+    });
+
+    it("ページサイズぴったり30件の取得で hasMoreCompleted が true のまま", async () => {
+      chain._result = { data: [], error: null };
+      const { result } = renderHook(() => useTasks(HOUSEHOLD_ID), { wrapper: createQueryWrapper() });
+      await waitFor(() => expect(result.current.loading).toBe(false));
+      expect(result.current.hasMoreCompleted).toBe(true);
+
+      const batch30 = Array.from({ length: 30 }, (_, i) =>
+        makeTask({
+          id: `batch-${i}`,
+          is_done: true,
+          completed_at: `2023-${String(i + 1).padStart(2, "0")}-01T00:00:00Z`,
+        })
+      );
+      chain._result = { data: batch30, error: null };
+
+      await act(async () => {
+        await result.current.loadMoreCompleted();
+      });
+
+      expect(result.current.hasMoreCompleted).toBe(true);
     });
 
     it("重複 id は追記されない", async () => {

--- a/src/lib/avatar.test.ts
+++ b/src/lib/avatar.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from "vitest";
+import { getAvatarEmoji, avatarUrlFromKey, AVATAR_PRESETS } from "@/lib/avatar";
+
+describe("getAvatarEmoji", () => {
+  it("既知のキーは対応する絵文字を返す", () => {
+    expect(getAvatarEmoji("emoji:cat")).toBe("🐱");
+  });
+
+  it("全プリセットキーが絵文字に解決できる", () => {
+    for (const preset of AVATAR_PRESETS) {
+      expect(getAvatarEmoji(`emoji:${preset.key}`)).toBe(preset.emoji);
+    }
+  });
+
+  it("存在しないキーは null を返す", () => {
+    expect(getAvatarEmoji("emoji:unknown_key_xyz")).toBeNull();
+  });
+
+  it("null 入力は null を返す", () => {
+    expect(getAvatarEmoji(null)).toBeNull();
+  });
+
+  it("undefined 入力は null を返す", () => {
+    expect(getAvatarEmoji(undefined)).toBeNull();
+  });
+
+  it("emoji: プレフィックスなしは null を返す", () => {
+    expect(getAvatarEmoji("cat")).toBeNull();
+  });
+
+  it("https:// URL は null を返す（カスタムアバター URL）", () => {
+    expect(getAvatarEmoji("https://example.com/avatar.png")).toBeNull();
+  });
+});
+
+describe("avatarUrlFromKey", () => {
+  it("key から emoji: プレフィックス付き URL を生成する", () => {
+    expect(avatarUrlFromKey("cat")).toBe("emoji:cat");
+  });
+
+  it("getAvatarEmoji と往復できる", () => {
+    const key = "dog";
+    const url = avatarUrlFromKey(key);
+    expect(getAvatarEmoji(url)).toBe("🐶");
+  });
+});

--- a/src/lib/date.test.ts
+++ b/src/lib/date.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { formatDueDate, getQuickDate } from "@/lib/date";
+
+describe("formatDueDate", () => {
+  beforeEach(() => {
+    // 2024-06-15 12:00:00 UTC に固定
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-06-15T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("当日の日付は「今日」を返す", () => {
+    expect(formatDueDate("2024-06-15T00:00:00Z")).toBe("今日");
+  });
+
+  it("翌日の日付は「明日」を返す", () => {
+    expect(formatDueDate("2024-06-16T00:00:00Z")).toBe("明日");
+  });
+
+  it("それ以外は M/D 形式を返す", () => {
+    expect(formatDueDate("2024-07-04T00:00:00Z")).toBe("7/4");
+  });
+
+  it("1桁の月・日もそのまま返す", () => {
+    expect(formatDueDate("2024-01-09T00:00:00Z")).toBe("1/9");
+  });
+
+  it("過去の日付も M/D 形式で返す", () => {
+    expect(formatDueDate("2024-03-20T00:00:00Z")).toBe("3/20");
+  });
+});
+
+describe("getQuickDate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2024-06-15T12:00:00Z"));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("offset=0 は今日の YYYY-MM-DD を返す", () => {
+    expect(getQuickDate(0)).toBe("2024-06-15");
+  });
+
+  it("offset=1 は明日の YYYY-MM-DD を返す", () => {
+    expect(getQuickDate(1)).toBe("2024-06-16");
+  });
+
+  it("offset=3 は3日後の YYYY-MM-DD を返す", () => {
+    expect(getQuickDate(3)).toBe("2024-06-18");
+  });
+
+  it("月末をまたぐ場合も正しく計算される", () => {
+    vi.setSystemTime(new Date("2024-06-30T12:00:00Z"));
+    expect(getQuickDate(1)).toBe("2024-07-01");
+  });
+});

--- a/src/lib/validation.test.ts
+++ b/src/lib/validation.test.ts
@@ -1,0 +1,40 @@
+import { describe, it, expect } from "vitest";
+import { isValidUrl } from "@/lib/validation";
+
+describe("isValidUrl", () => {
+  it("https:// URL は有効", () => {
+    expect(isValidUrl("https://example.com")).toBe(true);
+  });
+
+  it("http:// URL は有効", () => {
+    expect(isValidUrl("http://example.com")).toBe(true);
+  });
+
+  it("パス・クエリを含む URL は有効", () => {
+    expect(isValidUrl("https://example.com/path?q=1#hash")).toBe(true);
+  });
+
+  it("プロトコルなしのベアドメインは無効", () => {
+    expect(isValidUrl("example.com")).toBe(false);
+  });
+
+  it("javascript: スキームは無効", () => {
+    expect(isValidUrl("javascript:alert(1)")).toBe(false);
+  });
+
+  it("data: スキームは無効", () => {
+    expect(isValidUrl("data:text/html,<h1>hi</h1>")).toBe(false);
+  });
+
+  it("ftp:// は無効", () => {
+    expect(isValidUrl("ftp://files.example.com")).toBe(false);
+  });
+
+  it("空文字は無効", () => {
+    expect(isValidUrl("")).toBe(false);
+  });
+
+  it("スペースのみは無効", () => {
+    expect(isValidUrl("   ")).toBe(false);
+  });
+});

--- a/src/test/mocks/supabase.ts
+++ b/src/test/mocks/supabase.ts
@@ -20,6 +20,8 @@ export class MockQueryChain {
   order = vi.fn().mockReturnThis();
   limit = vi.fn().mockReturnThis();
   single = vi.fn().mockResolvedValue({ data: null, error: null });
+  maybeSingle = vi.fn().mockResolvedValue({ data: null, error: null });
+  upsert = vi.fn().mockReturnThis();
 
   // Thenable interface — `await chain` でここが呼ばれる
   then<T = any>(


### PR DESCRIPTION
既存テストの修正・拡張、新規テスト追加で 33→97 テストに増加。

- fix: useCategories reorderCategories の壊れたテストを修正
  （TanStack Query のバックグラウンド再フェッチと競合しないよう chain._result を事前更新）
- feat: useCategories に addCategory エラーケース・color のみ更新テスト追加
- feat: useTasks に deleteTask ロールバック・loadMoreCompleted 30件境界テスト追加
- feat: usePageData テスト新規追加（セッションなし/リダイレクト/upsert/エラー）
- feat: useRealtimeTasks テスト新規追加（INSERT/UPDATE/DELETE/dedup/cleanup）
- feat: useRealtimeStapleItems テスト新規追加（同上）
- feat: useSort テスト新規追加（localStorage 永続化・フォールバック）
- feat: useTaskRecommendations テスト新規追加（RPC/dismiss/dismissed_until 計算）
- feat: lib/validation・lib/date・lib/avatar のユニットテスト新規追加
- chore: MockQueryChain に maybeSingle・upsert を追加

https://claude.ai/code/session_01R7gm4xKmhffFaW71Vsr84V