### PR TITLE
feat: 定番品・レコメンド機能の拡充とパフォーマンス/セキュリティ改善

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -20,7 +20,11 @@
       "Bash(sudo xcodebuild -license accept)",
       "Bash(grep -r \"sanitize\\\\|DOMPurify\\\\|dangerouslySetInnerHTML\\\\|innerHTML\" /Users/naikiwatanabe/Documents/family-task-app/src --include=\"*.tsx\" --include=\"*.ts\" 2>/dev/null | head -10)",
       "Bash(docker exec supabase_db_family-task-app psql postgresql://postgres:postgres@localhost:5432/postgres -c \"\\\\d auth.identities\" 2>&1)",
-      "Bash(npm run test:run 2>&1)"
+      "Bash(npm run test:run 2>&1)",
+      "Bash(gh pr *)",
+      "Bash(git fetch *)",
+      "Bash(git stash *)",
+      "Bash(git rebase *)"
     ]
   },
   "enableAllProjectMcpServers": true,


### PR DESCRIPTION
## 変更内容

`main` 未マージの作業をまとめた PR です（30 コミット / 43 ファイル / +2012 −423）。主な内容は以下のとおり。

### 機能
- 完了済みタスクの段階ロード（`loadMoreCompleted` / `COMPLETED_PAGE_SIZE = 30`）を追加
- 定番品カードにカテゴリー色バッジを表示、追加時のトースト挙動を改善
- 定番品シートのヘッダー見切れ・カード高さ不揃いなど UI 不具合を修正

### パフォーマンス
- React Query を導入し、ページ遷移時のサーバーステート再取得を排除
- 起動時のデータ取得・認証往復を削減
- 重い非クリティカル取得を `runWhenIdle` でアイドル時に逃がす

### セキュリティ / DB（マイグレーション）
- **013** `lock_profile_household_update.sql` — `profiles` UPDATE に `WITH CHECK` を追加し、`household_id` の直接書き換えによる世帯横移動を防止。`create_household_with_defaults` RPC を新設
- **014** `fix_invite_code_extensions_schema.sql` — 招待コード生成 RPC の `gen_random_bytes` を `extensions` スキーマで完全修飾し、再発行失敗を修正
- `src/types/database.ts` を上記マイグレーションに合わせて再生成

### リファクタ / テスト / 雑務
- 肥大化した定番品・カテゴリ管理コンポーネントを分割
- `useCategories` の楽観的更新・ロールバックを既存パターンに統一
- フック / lib のテストカバレッジを大幅拡充
- git / gh 操作コマンドの許可リストを追加

## マイグレーション影響範囲
- `013` / `014` を含む。`013` は `profiles` の UPDATE ポリシー変更（RLS 強化）と新規 RPC 追加。世帯の作成・参加は引き続き RPC 経由のみ。データ消失を伴う `DROP` はなし。
- 本番反映前に `npx supabase db push` のレビューが必要。

## 動作確認
- `npm run test:run`（Vitest 単発）でテストパスを確認
- ローカル Supabase で `npx supabase db reset` によりマイグレーション全適用を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)