### PR TITLE
perf: 世帯idをキャッシュし起動時のクエリを並列化

### DIFF
--- a/docs/startup-flow.md
+++ b/docs/startup-flow.md
@@ -1,0 +1,72 @@
+# アプリ起動〜初回描画のフロー
+
+家族タスクアプリを開いてからタスクが表示されるまでの流れ。
+「対応前」は profiles 取得を待ってからタスク取得が始まる直列構造、
+「対応後」は householdId を localStorage にキャッシュして並列化した構造。
+
+## 対応前：profiles を待ってからタスク取得（直列）
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as ブラウザ(画面)
+    participant MW as middleware
+    participant SB as Supabase
+
+    U->>MW: アプリを開く
+    MW->>SB: 認証チェック(getUser)
+    SB-->>MW: OK
+    MW-->>U: ページ返却
+
+    Note over U: usePageData 実行
+    U->>SB: profiles取得(どの家族?)
+    SB-->>U: household_id 判明
+    Note over U: ここで初めて家族IDが分かる
+
+    U->>SB: tasks取得
+    U->>SB: categories取得
+    U->>SB: staple取得
+    SB-->>U: データ返却
+    Note over U: 描画（往復が直列に積み上がる）
+```
+
+## 対応後：キャッシュ済みIDで即並列取得
+
+```mermaid
+sequenceDiagram
+    autonumber
+    participant U as ブラウザ(画面)
+    participant LS as localStorage
+    participant SB as Supabase
+
+    U->>LS: household_id を読む(即時・往復なし)
+    LS-->>U: household_id
+
+    par 同時に開始
+        U->>SB: tasks取得
+    and
+        U->>SB: categories取得
+    and
+        U->>SB: staple取得
+    and
+        U->>SB: profiles取得(確認・是正用)
+    end
+    SB-->>U: データ返却
+    Note over U: 描画（profiles待ちが消え往復1回分速い）
+
+    Note over U,SB: 万一IDが古ければ profiles の結果で自動的に取り直す
+```
+
+## ポイント
+
+- 変わったのは「タスク取得の開始タイミング」。対応前は profiles の応答を待ってから、
+  対応後はキャッシュした household_id を使って profiles と同時にスタートする。
+- 初回（キャッシュ無し）は対応前と同じ流れ。2回目以降の起動が速くなる。
+- ログアウト・世帯切り替え時はキャッシュを消すため、別の家族の情報が混ざらない。
+
+## 関連ファイル
+
+- `src/lib/household-cache.ts` — localStorage への id/名前キャッシュ（get/set/clear）
+- `src/hooks/use-page-data.ts` — キャッシュ反映・更新・無効化
+- `src/app/page.tsx` — キャッシュ済み householdId をフォールバックに各クエリを早期発火
+```

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -36,6 +36,7 @@ import { BottomSheet } from "@/components/ui/bottom-sheet";
 import { useTaskRecommendations } from "@/hooks/use-task-recommendations";
 import { useTitleSuggestions } from "@/hooks/use-title-suggestions";
 import { usePageData } from "@/hooks/use-page-data";
+import { getCachedHouseholdId } from "@/lib/household-cache";
 import { useStapleItems } from "@/hooks/use-staple-items";
 import { useRealtimeStapleItems } from "@/hooks/use-realtime-staple-items";
 import type { TabMeasurements } from "@/components/category/category-tabs";
@@ -74,7 +75,15 @@ export default function Home() {
     tabMeasurementsRef.current = m;
   }, []);
 
-  const householdId = profile?.household_id ?? null;
+  // 前回セッションでキャッシュした householdId をマウント後に読み出し、
+  // profiles 取得を待たずに tasks/categories/staple/Realtime を並列発火させる。
+  // （useEffect で読むことで SSR とのハイドレーション不整合を避ける）
+  const [cachedHouseholdId, setCachedHouseholdId] = useState<string | null>(null);
+  useEffect(() => {
+    setCachedHouseholdId(getCachedHouseholdId());
+  }, []);
+  // profile 確定後はそちらを正とする（世帯切替時はキー変更で自動再取得される）
+  const householdId = profile?.household_id ?? cachedHouseholdId;
   const supabase = useMemo(() => createClient(), []);
   const { categories } = useCategories(householdId);
   const { tasks: allTasks, setTasks, loading: tasksLoading, addTask, updateTask, deleteTask, toggleTask, reorderTasks, loadMoreCompleted, hasMoreCompleted, loadingMoreCompleted } =

--- a/src/app/settings/page.tsx
+++ b/src/app/settings/page.tsx
@@ -9,6 +9,7 @@ import { CategorySettings } from "@/components/settings/category-settings";
 import { NotificationSettings } from "@/components/settings/notification-settings";
 import { useCategories } from "@/hooks/use-categories";
 import { usePageData } from "@/hooks/use-page-data";
+import { clearCachedHousehold } from "@/lib/household-cache";
 
 export default function SettingsPage() {
   const router = useRouter();
@@ -22,6 +23,7 @@ export default function SettingsPage() {
 
   const handleLogout = async () => {
     const supabase = createClient();
+    clearCachedHousehold();
     await supabase.auth.signOut();
     router.push("/login");
     router.refresh();

--- a/src/components/household/create-form.tsx
+++ b/src/components/household/create-form.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
+import { setCachedHousehold } from "@/lib/household-cache";
 
 export function CreateHouseholdForm() {
   const router = useRouter();
@@ -30,6 +31,8 @@ export function CreateHouseholdForm() {
       return;
     }
 
+    // 次回起動の並列化のため、作成直後に id/名前をキャッシュ
+    setCachedHousehold(householdId, trimmedName);
     router.push("/");
     router.refresh();
   };

--- a/src/components/household/join-form.tsx
+++ b/src/components/household/join-form.tsx
@@ -3,6 +3,7 @@
 import { useState } from "react";
 import { useRouter } from "next/navigation";
 import { createClient } from "@/lib/supabase/client";
+import { clearCachedHousehold } from "@/lib/household-cache";
 
 export function JoinHouseholdForm() {
   const router = useRouter();
@@ -27,6 +28,9 @@ export function JoinHouseholdForm() {
       return;
     }
 
+    // 参加先の世帯名はここでは不明なため、古いキャッシュを消して
+    // usePageData の再取得に任せる（誤った世帯名の表示を防ぐ）
+    clearCachedHousehold();
     router.push("/");
     router.refresh();
   };

--- a/src/hooks/use-page-data.ts
+++ b/src/hooks/use-page-data.ts
@@ -4,6 +4,11 @@ import { useState, useEffect } from "react";
 import { useRouter } from "next/navigation";
 import { toast } from "sonner";
 import { createClient } from "@/lib/supabase/client";
+import {
+  getCachedHouseholdName,
+  setCachedHousehold,
+  clearCachedHousehold,
+} from "@/lib/household-cache";
 import type { Profile, Household } from "@/types";
 
 interface UsePageDataOptions {
@@ -32,6 +37,11 @@ export function usePageData(options: UsePageDataOptions = {}): PageData {
 
   useEffect(() => {
     const load = async () => {
+      // キャッシュ済みの世帯名を即時反映してヘッダーの CLS を防ぐ
+      // （マウント後の実行なのでハイドレーション不整合は起きない）
+      const cachedName = getCachedHouseholdName();
+      if (cachedName) setHouseholdName(cachedName);
+
       const supabase = createClient();
       // middleware が全リクエストでサーバ側セッション検証を済ませているため、
       // ここはネットワーク往復のない getSession() で十分（認証往復の二重化を回避）
@@ -41,6 +51,7 @@ export function usePageData(options: UsePageDataOptions = {}): PageData {
       const user = session?.user;
 
       if (!user) {
+        clearCachedHousehold();
         router.push("/login");
         setLoading(false);
         return;
@@ -70,6 +81,7 @@ export function usePageData(options: UsePageDataOptions = {}): PageData {
       }
 
       if (!p.household_id && redirectIfNoHousehold) {
+        clearCachedHousehold();
         setProfile(p);
         router.push("/household/new");
         setLoading(false);
@@ -79,24 +91,28 @@ export function usePageData(options: UsePageDataOptions = {}): PageData {
       setProfile(p);
 
       if (p.household_id) {
+        const hid = p.household_id;
         if (fetchHousehold) {
           const [householdResult, membersResult] = await Promise.all([
             supabase
               .from("households")
               .select("*")
-              .eq("id", p.household_id)
+              .eq("id", hid)
               .single(),
             supabase
               .from("profiles")
               .select("*")
-              .eq("household_id", p.household_id)
+              .eq("household_id", hid)
               .order("created_at", { ascending: true }),
           ]);
 
           if (householdResult.error) toast.error("ハウスホールドの取得に失敗しました");
           if (householdResult.data) {
             setHousehold(householdResult.data);
-            if (householdResult.data.name) setHouseholdName(householdResult.data.name);
+            if (householdResult.data.name) {
+              setHouseholdName(householdResult.data.name);
+              setCachedHousehold(hid, householdResult.data.name);
+            }
           }
 
           if (membersResult.error) toast.error("メンバーの取得に失敗しました");
@@ -106,7 +122,7 @@ export function usePageData(options: UsePageDataOptions = {}): PageData {
           supabase
             .from("profiles")
             .select("*")
-            .eq("household_id", p.household_id)
+            .eq("household_id", hid)
             .then(({ data, error }) => {
               if (error) toast.error("メンバーの取得に失敗しました");
               if (data) setMembers(data);
@@ -115,10 +131,14 @@ export function usePageData(options: UsePageDataOptions = {}): PageData {
           supabase
             .from("households")
             .select("name")
-            .eq("id", p.household_id)
+            .eq("id", hid)
             .single()
             .then(({ data }) => {
-              if (data?.name) setHouseholdName(data.name);
+              if (data?.name) {
+                setHouseholdName(data.name);
+                // 次回起動で profiles を待たずに名前・id を即時利用するためキャッシュ
+                setCachedHousehold(hid, data.name);
+              }
             });
         }
       }

--- a/src/lib/household-cache.test.ts
+++ b/src/lib/household-cache.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect, beforeEach, vi, afterEach } from "vitest";
+import {
+  getCachedHouseholdId,
+  getCachedHouseholdName,
+  setCachedHousehold,
+  clearCachedHousehold,
+} from "@/lib/household-cache";
+
+describe("household-cache", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("未設定時は id / name とも null", () => {
+    expect(getCachedHouseholdId()).toBeNull();
+    expect(getCachedHouseholdName()).toBeNull();
+  });
+
+  it("set した id / name を取得できる", () => {
+    setCachedHousehold("household-1", "わが家");
+    expect(getCachedHouseholdId()).toBe("household-1");
+    expect(getCachedHouseholdName()).toBe("わが家");
+  });
+
+  it("clear で消える", () => {
+    setCachedHousehold("household-1", "わが家");
+    clearCachedHousehold();
+    expect(getCachedHouseholdId()).toBeNull();
+    expect(getCachedHouseholdName()).toBeNull();
+  });
+
+  it("壊れた JSON は null を返す", () => {
+    window.localStorage.setItem("family-task:household-cache", "{not json");
+    expect(getCachedHouseholdId()).toBeNull();
+    expect(getCachedHouseholdName()).toBeNull();
+  });
+
+  it("id / name が欠けたオブジェクトは null を返す", () => {
+    window.localStorage.setItem(
+      "family-task:household-cache",
+      JSON.stringify({ id: "household-1" })
+    );
+    expect(getCachedHouseholdId()).toBeNull();
+    expect(getCachedHouseholdName()).toBeNull();
+  });
+
+  it("localStorage の setItem が例外を投げても落ちない", () => {
+    vi.spyOn(window.localStorage, "setItem").mockImplementation(() => {
+      throw new Error("QuotaExceeded");
+    });
+    expect(() => setCachedHousehold("household-1", "わが家")).not.toThrow();
+  });
+});

--- a/src/lib/household-cache.ts
+++ b/src/lib/household-cache.ts
@@ -1,0 +1,65 @@
+/**
+ * 直近にアクセスした世帯の id / 名前を localStorage にキャッシュする軽量ヘルパ。
+ *
+ * 目的：起動時に householdId を即座に得て、profiles 取得を待たずに
+ * tasks / categories / staple / Realtime を並列発火させる（直列往復を1回削減）。
+ * householdName も即時表示してヘッダーの CLS を解消する。
+ *
+ * SSR ガードと try/catch を必ず通すこと（プライベートブラウズ等で localStorage が
+ * 例外を投げてもキャッシュ無し＝従来フローへフォールバックする）。
+ */
+
+const STORAGE_KEY = "family-task:household-cache";
+
+interface HouseholdCache {
+  id: string;
+  name: string;
+}
+
+function read(): HouseholdCache | null {
+  if (typeof window === "undefined") return null;
+  try {
+    const raw = window.localStorage.getItem(STORAGE_KEY);
+    if (!raw) return null;
+    const parsed: unknown = JSON.parse(raw);
+    if (
+      typeof parsed === "object" &&
+      parsed !== null &&
+      "id" in parsed &&
+      "name" in parsed &&
+      typeof (parsed as Record<string, unknown>).id === "string" &&
+      typeof (parsed as Record<string, unknown>).name === "string"
+    ) {
+      return parsed as HouseholdCache;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+export function getCachedHouseholdId(): string | null {
+  return read()?.id ?? null;
+}
+
+export function getCachedHouseholdName(): string | null {
+  return read()?.name ?? null;
+}
+
+export function setCachedHousehold(id: string, name: string): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ id, name }));
+  } catch {
+    // localStorage 不可（プライベートブラウズ等）は無視
+  }
+}
+
+export function clearCachedHousehold(): void {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.removeItem(STORAGE_KEY);
+  } catch {
+    // 無視
+  }
+}


### PR DESCRIPTION
profiles 取得を待ってから tasks/categories/staple が直列に走る構造を、
householdId/householdName を localStorage にキャッシュすることで解消する。

マウント後にキャッシュ済み householdId を読み出し、profiles 再取得と並列で
タスク等のクエリと Realtime 購読を発火させる。これにより初回描画までの
ネットワーク往復が実質1回減り、世帯名の即時表示でヘッダーの CLS も解消する。

ログアウト・世帯未設定リダイレクト・世帯参加時はキャッシュを無効化し、
世帯作成・名前取得時に最新値で更新する。profiles 確定後はそちらを正とし、
不一致時は React Query のキー変更で自動的に再取得される。

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01MSfmkfmMzEn2z7L2tQ1xU6